### PR TITLE
Make phone and TV pairing recoverable

### DIFF
--- a/docs/_translations/de/setup.md
+++ b/docs/_translations/de/setup.md
@@ -47,6 +47,13 @@ Die Kopplung ist normalerweise nur einmal nötig. Den Dienst zu starten ist ein 
 
 Wenn du unter **Einstellungen**, **Startverhalten**, **Kopplungsmethode** die Option **Dialog in der App** ausgewählt hast, warte im Dialog auf die Erkennung des Kopplungsdienstes und gib den Code dort ein. Falls nach einem Port gefragt wird, verwende den Kopplungsport aus Androids Kopplungscode-Dialog. Er unterscheidet sich vom Verbindungsport auf der Hauptseite für drahtloses Debugging.
 
+### Android TV
+{: #android-tv }
+
+Wähle auf einem Fernseher mit drahtlosem Debugging in Porter **Kopplung** und folge den Anweisungen zum Aktivieren des Bedienungshilfedienstes für die Kopplung. Öffne innerhalb einer Minute die **Entwickleroptionen**, **Debugging über WLAN** und anschließend **Gerät mit Kopplungscode koppeln**. Lass diesen Dialog geöffnet, während Porter den Code liest und die Kopplung abschließt.
+
+Porter zeigt das Ergebnis an und schaltet seinen Bedienungshilfedienst für die Kopplung aus. Wähle nach erfolgreicher Kopplung **Starten** oder nach einem Fehler beziehungsweise einer Zeitüberschreitung **Erneut versuchen**. Öffnet sich Porter nicht automatisch, öffne die App, um das Ergebnis zu sehen. Bei Installationsschaltflächen, die sich nicht mit der Fernbedienung auswählen lassen, helfen die Hinweise zu [Installationswarnungen auf dem Fernseher](/troubleshooting#a-tv-installation-warning-cannot-be-selected-with-the-remote).
+
 ## Mit einem Computer
 {: #with-a-computer }
 

--- a/docs/_translations/de/troubleshooting.md
+++ b/docs/_translations/de/troubleshooting.md
@@ -29,6 +29,12 @@ Der automatische Start hängt weiterhin davon ab, ob Android Debugging-Zugriff b
 - Wenn du den Kopplungscode in Porters Dialog eingibst, übernimm den Kopplungsport aus dem Kopplungscode-Dialog. Verwende nicht den Verbindungsport auf der Hauptseite für drahtloses Debugging.
 - Falls ein VPN oder eine Einschränkung im lokalen Netzwerk die Erkennung verhindert, versuche es in einem Netzwerk, das die Kommunikation zwischen Geräten erlaubt.
 
+Wenn ein Code abgelehnt wurde, wähle in der Benachrichtigung **Erneut versuchen**. Fehlt die Benachrichtigung oder zeigt sie noch einen alten Code, kehre in Porter zur **Kopplung** zurück und wähle **Kopplung neu starten**. Schließe Androids alten Kopplungscode-Dialog, öffne einen neuen und gib den neuen Code ein. Porters Cache oder App-Daten musst du nicht löschen.
+
+Auf Android TV zeigt Porter an, ob die Kopplung erfolgreich war, fehlgeschlagen ist oder abgelaufen ist. Wähle nach einem Fehler **Erneut versuchen** und aktiviere den Bedienungshilfedienst für die Kopplung erneut, falls du dazu aufgefordert wirst. Öffnet sich Porter nicht automatisch, öffne die App, um das gespeicherte Ergebnis zu sehen. Nach erfolgreicher Kopplung folgt der separate Schritt **Starten**.
+
+Neue Kopplungen erscheinen in Androids Liste gekoppelter Geräte als **Porter**. Ein vorhandener Eintrag kann weiterhin **shizuku** heißen, bis du ihn entfernst und erneut koppelst. Der gespeicherte Schlüssel muss für die neue Bezeichnung nicht ersetzt werden; bestehende Kopplungen können weiter funktionieren. Diese Bezeichnung ist unabhängig von den Shizuku-API-Kennzeichnungen in Porters App-Liste.
+
 Wenn drahtloses Debugging auf deinem Gerät nicht verfügbar oder unzuverlässig ist, [starte Porter über einen Computer](/setup#with-a-computer).
 
 ## Der Computer findet das Gerät nicht
@@ -64,6 +70,21 @@ Wenn du die Begleit-App nutzt, müssen beide Porter-APKs aus derselben Veröffen
 Falls du **Porter Compatibility** installierst, deinstalliere zuerst Shizuku. Die Begleit-App kann eine anders signierte Shizuku-Installation nicht aktualisieren, obwohl Android dieselbe App-Identität erkennt.
 
 Bei Porter selbst kann ein älterer Entwicklungsbuild eine andere Signatur als eine öffentliche Veröffentlichung haben. Android installiert die eine Version nicht über die andere. Eine Deinstallation entfernt auch die App-Daten. Notiere daher vorher deine Einrichtung. Installiere Porter aus der gewünschten Quelle neu und erlaube deinen Apps erneut den Zugriff.
+
+## Eine Installationswarnung auf dem Fernseher lässt sich nicht mit der Fernbedienung bedienen
+{: #a-tv-installation-warning-cannot-be-selected-with-the-remote }
+
+Die Play-Protect-Warnung und ihre Schaltflächen **Weitere Details** oder **Trotzdem installieren** gehören zum Android-Installationsprogramm. Porter kann deren Fokussteuerung per Fernbedienung nicht ändern. Die Warnung allein erklärt auch nicht, warum Google eine APK beanstandet.
+
+Prüfe, ob die APK von der [Porter-Veröffentlichungsseite](https://github.com/d4rken-org/porter/releases) stammt. Wenn du die Warnung gelesen hast und fortfahren möchtest, lassen sich die Schaltflächen möglicherweise mit einer USB- oder Bluetooth-Maus auswählen. Besteht bereits eine autorisierte ADB-Verbindung zum Fernseher, kannst du die heruntergeladene APK auch von diesem Computer aus installieren:
+
+```sh
+adb -s TV_SERIAL install -r /pfad/zu/porter-compat.apk
+```
+
+Ersetze `TV_SERIAL` durch den Eintrag des Fernsehers aus `adb devices` und verwende den tatsächlichen Pfad zur heruntergeladenen APK. Android kann die Installation weiterhin blockieren oder eine Bestätigung verlangen. Das repariert die Play-Protect-Steuerung nicht und garantiert keine erfolgreiche Installation.
+
+Falls die Installation blockiert bleibt, melde den genauen Warntext, das TV-Modell, die Android-Version und die Version von Porter Compatibility. Apps mit direkter Porter-Unterstützung benötigen die Kompatibilitäts-APK nicht.
 
 ## Zugriff ist erlaubt, aber ein Vorgang schlägt trotzdem fehl
 {: #access-is-allowed-but-an-operation-still-fails }

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -42,6 +42,12 @@ Pairing normally only needs to be done once. Starting the service is a separate 
 
 If you selected **In-app dialog** under **Settings**, **Startup**, **Pairing method**, wait for Porter's dialog to discover the pairing service, then enter the code there. If it asks for a port, use the pairing port from Android's pairing-code dialog, not the connection port on the main Wireless debugging screen.
 
+### Android TV
+
+On a TV with wireless debugging, choose **Pairing** in Porter and follow the instructions to enable its pairing accessibility service. Within one minute, open **Developer options**, **Wireless debugging**, then **Pair device with pairing code**. Keep that dialog open while Porter reads the code and completes pairing.
+
+Porter shows the result and turns off its pairing accessibility service. Choose **Start** after success, or **Retry** after a failure or timeout. If Porter does not open automatically, open it to see the result. For installation controls that cannot be selected with a remote, see [TV installation warnings](/troubleshooting#a-tv-installation-warning-cannot-be-selected-with-the-remote).
+
 ## With a computer
 
 1. Install Google's [Android SDK Platform-Tools](https://developer.android.com/tools/releases/platform-tools) on your computer.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -24,6 +24,12 @@ Automatic start still depends on Android making debugging access available and a
 - If entering the pairing code in Porter's in-app dialog, copy the pairing port from the pairing-code dialog, not the connection port on the main Wireless debugging screen.
 - If a VPN or local-network restriction blocks discovery, try a network where device communication is allowed.
 
+If a code was rejected, choose **Retry** in the notification. If the notification is missing or still shows an old code, return to **Pairing** in Porter and choose **Restart pairing**. Close Android's old pairing-code dialog and open a new one, then enter the new code. You do not need to clear Porter's cache or app data.
+
+On Android TV, Porter shows a result when pairing succeeds, fails or times out. Choose **Retry** after a failure; enable the pairing accessibility service again if asked. If Porter does not open automatically, open it to see the saved result. Pairing success is followed by a separate **Start** step.
+
+New pairings appear as **Porter** in Android's paired-device list. An existing entry may still say **shizuku** until you forget that entry and pair again. Renaming the display label does not require replacing the saved key, and an existing pairing can keep working. This label is separate from the Shizuku API badges in Porter's app list.
+
 When wireless debugging is unavailable or unreliable on your device, [start from a computer](/setup#with-a-computer).
 
 ## The computer cannot find the device
@@ -55,6 +61,20 @@ If you use the companion, both Porter APKs must come from the same release sourc
 If you are installing **Porter Compatibility**, remove Shizuku first. The companion cannot update a differently signed Shizuku installation, even though Android sees the same app identity.
 
 For Porter itself, an older development build may have a different signature from a public release. Android will not install one over the other. Removing the old installation also removes its app data; record your setup before doing so. Reinstall from the intended source and approve your apps again.
+
+## A TV installation warning cannot be selected with the remote
+
+The Play Protect warning and its **More details** or **Install anyway** controls belong to Android's installer. Porter cannot change their remote-control focus behavior, and the warning alone does not tell us why Google flagged an APK.
+
+Check that the APK came from the [Porter release page](https://github.com/d4rken-org/porter/releases). If you decide to continue after reading the warning, a USB or Bluetooth mouse may let you select its controls. If you already have an authorized ADB connection to the TV, you can also try installing the downloaded APK from that computer:
+
+```sh
+adb -s TV_SERIAL install -r /path/to/porter-compat.apk
+```
+
+Replace `TV_SERIAL` with the TV's entry from `adb devices` and use the actual downloaded APK path. Android may still block installation or require confirmation. This does not fix Play Protect's controls or guarantee that installation is allowed.
+
+If installation remains blocked, report the exact warning text, TV model, Android version and Porter Compatibility version. Apps with direct Porter support do not need the compatibility APK.
 
 ## Access is allowed, but an operation still fails
 

--- a/manager/src/main/java/moe/shizuku/manager/adb/AdbKey.kt
+++ b/manager/src/main/java/moe/shizuku/manager/adb/AdbKey.kt
@@ -38,7 +38,7 @@ import javax.net.ssl.X509ExtendedTrustManager
 
 private const val TAG = "AdbKey"
 
-class AdbKey(private val adbKeyStore: AdbKeyStore, name: String) {
+class AdbKey(private val adbKeyStore: AdbKeyStore, name: String = "Porter") {
 
     companion object {
 

--- a/manager/src/main/java/moe/shizuku/manager/adb/AdbMdns.kt
+++ b/manager/src/main/java/moe/shizuku/manager/adb/AdbMdns.kt
@@ -4,9 +4,17 @@ import android.content.Context
 import android.net.nsd.NsdManager
 import android.net.nsd.NsdServiceInfo
 import android.os.Build
+import android.os.Handler
+import android.os.Looper
 import android.util.Log
 import androidx.annotation.RequiresApi
 import androidx.lifecycle.Observer
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import java.io.IOException
 import java.net.InetSocketAddress
 import java.net.NetworkInterface
@@ -17,58 +25,121 @@ class AdbMdns(
     context: Context, private val serviceType: String,
     private val observer: Observer<Pair<String, Int>>
 ) {
-
-    private var registered = false
-    private var running = false
-    private var serviceName: String? = null
-    private val listener = DiscoveryListener(this)
-    private val nsdManager: NsdManager = context.getSystemService(NsdManager::class.java)
+    private val handler = Handler(Looper.getMainLooper())
+    private val nsdManager = context.getSystemService(NsdManager::class.java)
+    private var listener: DiscoveryListener? = null
 
     fun start() {
-        if (running) return
-        running = true
-        if (!registered) {
-            nsdManager.discoverServices(serviceType, NsdManager.PROTOCOL_DNS_SD, listener)
+        if (Looper.myLooper() != handler.looper) { handler.post { start() }; return }
+        if (listener != null) return
+        val next = DiscoveryListener()
+        listener = next
+        try {
+            nsdManager.discoverServices(serviceType, NsdManager.PROTOCOL_DNS_SD, next)
+        } catch (e: Exception) {
+            Log.w(TAG, "Cannot start discovery", e)
+            listener = null
+            observer.onChanged("" to -1)
         }
     }
 
     fun stop() {
-        if (!running) return
-        running = false
-        if (registered) {
-            nsdManager.stopServiceDiscovery(listener)
+        if (Looper.myLooper() != handler.looper) { handler.post { stop() }; return }
+        val previous = listener ?: return
+        listener = null
+        previous.scope.cancel()
+        if (previous.registered) previous.stopDiscovery()
+        // Registration may still be pending. Its callback will stop the old listener.
+    }
+
+    private inner class DiscoveryListener : NsdManager.DiscoveryListener {
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+        var registered = false
+        private var serviceName: String? = null
+        private val found = mutableMapOf<String, NsdServiceInfo>()
+        private val active get() = listener === this
+
+        fun stopDiscovery() {
+            try {
+                nsdManager.stopServiceDiscovery(this)
+            } catch (e: Exception) {
+                Log.w(TAG, "Cannot stop discovery", e)
+            }
         }
-    }
 
-    private fun onDiscoveryStart() {
-        registered = true
-    }
+        override fun onDiscoveryStarted(serviceType: String) {
+            handler.post {
+                registered = true
+                if (!active) stopDiscovery()
+            }
+        }
 
-    private fun onDiscoveryStop() {
-        registered = false
-    }
-
-    private fun onServiceFound(info: NsdServiceInfo) {
-        nsdManager.resolveService(info, ResolveListener(this))
-    }
-
-    private fun onServiceLost(info: NsdServiceInfo) {
-        if (info.serviceName == serviceName) observer.onChanged("" to -1)
-    }
-
-    private fun onServiceResolved(resolvedService: NsdServiceInfo) {
-        val host = resolvedService.host?.hostAddress ?: return
-        if (running && NetworkInterface.getNetworkInterfaces()
-                .asSequence()
-                .any { networkInterface ->
-                    networkInterface.inetAddresses
-                        .asSequence()
-                        .any { host == it.hostAddress }
+        override fun onStartDiscoveryFailed(serviceType: String, errorCode: Int) {
+            handler.post {
+                Log.w(TAG, "Discovery failed: $errorCode")
+                if (active) {
+                    listener = null
+                    observer.onChanged("" to -1)
                 }
-            && isPortAvailable(host, resolvedService.port)
-        ) {
-            serviceName = resolvedService.serviceName
-            observer.onChanged(host to resolvedService.port)
+            }
+        }
+
+        override fun onDiscoveryStopped(serviceType: String) {
+            handler.post {
+                registered = false
+                if (active) {
+                    listener = null
+                    observer.onChanged("" to -1)
+                }
+            }
+        }
+
+        override fun onStopDiscoveryFailed(serviceType: String, errorCode: Int) {
+            Log.w(TAG, "Stopping discovery failed: $errorCode")
+        }
+
+        override fun onServiceFound(info: NsdServiceInfo) {
+            handler.post {
+                if (!active) return@post
+                found[info.serviceName] = info
+                try {
+                    nsdManager.resolveService(info, object : NsdManager.ResolveListener {
+                        override fun onResolveFailed(serviceInfo: NsdServiceInfo, errorCode: Int) {
+                            Log.w(TAG, "Resolving service failed: $errorCode")
+                        }
+                        override fun onServiceResolved(resolved: NsdServiceInfo) {
+                            handler.post resolved@{
+                                if (!active || found[info.serviceName] !== info) return@resolved
+                                val host = resolved.host?.hostAddress ?: return@resolved
+                                scope.launch {
+                                    val available = withContext(Dispatchers.IO) {
+                                        NetworkInterface.getNetworkInterfaces().asSequence().any { network ->
+                                            network.inetAddresses.asSequence().any { it.hostAddress == host }
+                                        } && isPortAvailable(host, resolved.port)
+                                    }
+                                    if (available && active && found[info.serviceName] === info) {
+                                        serviceName = info.serviceName
+                                        observer.onChanged(host to resolved.port)
+                                    }
+                                }
+                            }
+                        }
+                    })
+                } catch (e: Exception) {
+                    Log.w(TAG, "Cannot resolve service", e)
+                }
+            }
+        }
+
+        override fun onServiceLost(info: NsdServiceInfo) {
+            handler.post {
+                if (!active) return@post
+                found.remove(info.serviceName)
+                if (info.serviceName == serviceName) {
+                    serviceName = null
+                    observer.onChanged("" to -1)
+                }
+            }
         }
     }
 
@@ -79,49 +150,6 @@ class AdbMdns(
         }
     } catch (e: IOException) {
         true
-    }
-
-    internal class DiscoveryListener(private val adbMdns: AdbMdns) : NsdManager.DiscoveryListener {
-        override fun onDiscoveryStarted(serviceType: String) {
-            Log.v(TAG, "onDiscoveryStarted: $serviceType")
-
-            adbMdns.onDiscoveryStart()
-        }
-
-        override fun onStartDiscoveryFailed(serviceType: String, errorCode: Int) {
-            Log.v(TAG, "onStartDiscoveryFailed: $serviceType, $errorCode")
-        }
-
-        override fun onDiscoveryStopped(serviceType: String) {
-            Log.v(TAG, "onDiscoveryStopped: $serviceType")
-
-            adbMdns.onDiscoveryStop()
-        }
-
-        override fun onStopDiscoveryFailed(serviceType: String, errorCode: Int) {
-            Log.v(TAG, "onStopDiscoveryFailed: $serviceType, $errorCode")
-        }
-
-        override fun onServiceFound(serviceInfo: NsdServiceInfo) {
-            Log.v(TAG, "onServiceFound: ${serviceInfo.serviceName}")
-
-            adbMdns.onServiceFound(serviceInfo)
-        }
-
-        override fun onServiceLost(serviceInfo: NsdServiceInfo) {
-            Log.v(TAG, "onServiceLost: ${serviceInfo.serviceName}")
-
-            adbMdns.onServiceLost(serviceInfo)
-        }
-    }
-
-    internal class ResolveListener(private val adbMdns: AdbMdns) : NsdManager.ResolveListener {
-        override fun onResolveFailed(nsdServiceInfo: NsdServiceInfo, i: Int) {}
-
-        override fun onServiceResolved(nsdServiceInfo: NsdServiceInfo) {
-            adbMdns.onServiceResolved(nsdServiceInfo)
-        }
-
     }
 
     companion object {

--- a/manager/src/main/java/moe/shizuku/manager/adb/AdbPairing.kt
+++ b/manager/src/main/java/moe/shizuku/manager/adb/AdbPairing.kt
@@ -1,0 +1,45 @@
+package moe.shizuku.manager.adb
+
+import android.content.Context
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.suspendCancellableCoroutine
+import java.util.concurrent.atomic.AtomicReference
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+import moe.shizuku.manager.R
+import moe.shizuku.manager.ShizukuSettings
+import java.net.ConnectException
+import java.net.SocketTimeoutException
+
+internal suspend fun pairAdb(host: String, port: Int, code: String): Unit = suspendCancellableCoroutine { continuation ->
+    val activeClient = AtomicReference<AdbPairingClient?>()
+    continuation.invokeOnCancellation { activeClient.get()?.cancel() }
+    Dispatchers.IO.dispatch(continuation.context) {
+        try {
+            if (!continuation.isActive) return@dispatch
+            val key = try {
+                AdbKey(PreferenceAdbKeyStore(ShizukuSettings.getPreferences()))
+            } catch (e: Exception) {
+                throw AdbKeyException(e)
+            }
+            AdbPairingClient(host, port, code, key).use { client ->
+                activeClient.set(client)
+                if (!continuation.isActive) return@dispatch
+                if (!client.start()) throw AdbInvalidPairingCodeException()
+            }
+            continuation.resume(Unit)
+        } catch (e: Throwable) {
+            continuation.resumeWithException(e as? Exception ?: RuntimeException("Pairing failed", e))
+        } finally {
+            activeClient.set(null)
+        }
+    }
+}
+
+internal fun Context.pairingFailureMessage(error: Throwable): String = getString(when (error) {
+    is AdbInvalidPairingCodeException -> R.string.paring_code_is_wrong
+    is AdbKeyException -> R.string.adb_error_key_store
+    is ConnectException -> R.string.cannot_connect_port
+    is SocketTimeoutException -> R.string.porter_pairing_attempt_timeout
+    else -> R.string.porter_pairing_failed_retry
+})

--- a/manager/src/main/java/moe/shizuku/manager/adb/AdbPairingAccessibilityService.kt
+++ b/manager/src/main/java/moe/shizuku/manager/adb/AdbPairingAccessibilityService.kt
@@ -1,124 +1,129 @@
 package moe.shizuku.manager.adb
 
 import android.accessibilityservice.AccessibilityService
-import android.view.accessibility.AccessibilityEvent
 import android.content.Intent
 import android.os.Handler
 import android.os.Looper
+import android.util.Log
+import android.view.accessibility.AccessibilityEvent
+import android.view.accessibility.AccessibilityNodeInfo
 import android.widget.Toast
-import android.provider.Settings
-import android.content.ActivityNotFoundException
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
-import moe.shizuku.manager.R
 import moe.shizuku.manager.MainActivity
+import moe.shizuku.manager.R
 import moe.shizuku.manager.ShizukuSettings
-import moe.shizuku.manager.adb.PreferenceAdbKeyStore
-import moe.shizuku.manager.adb.AdbKey
-import moe.shizuku.manager.adb.AdbPairingClient
 import moe.shizuku.manager.home.HomeActivity
 import moe.shizuku.manager.utils.EnvironmentUtils
-import java.net.ConnectException
 
 class AdbPairingAccessibilityService : AccessibilityService() {
-
-    var port: Int? = null
-    var password: String? = null
-
     private val handler = Handler(Looper.getMainLooper())
+    private var scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+    private var pairing = false
+    private var finished = false
+    internal var pair: suspend (String, Int, String) -> Unit = ::pairAdb
+    private val timeout = Runnable {
+        finishPairing(false, getString(R.string.porter_pairing_search_timeout))
+    }
 
     override fun onServiceConnected() {
         super.onServiceConnected()
-        
         if (!(EnvironmentUtils.isTelevision() && EnvironmentUtils.isTlsSupported())) {
-            Toast.makeText(this, getString(R.string.toast_accessibility_tv_only), Toast.LENGTH_SHORT).show()
+            Toast.makeText(this, R.string.toast_accessibility_tv_only, Toast.LENGTH_SHORT).show()
             disableSelf()
             return
         }
+        startPairing()
+    }
 
-        val intent = Intent(this, MainActivity::class.java).apply {
-            addFlags(
-                Intent.FLAG_ACTIVITY_NEW_TASK or 
-                Intent.FLAG_ACTIVITY_CLEAR_TOP or
-                Intent.FLAG_ACTIVITY_SINGLE_TOP
-            )
-            putExtra(HomeActivity.EXTRA_SHOW_PAIRING_DIALOG, true)
+    internal fun startPairing() {
+        scope.cancel()
+        scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+        pairing = false
+        finished = false
+        TvPairingResultStore(ShizukuSettings.getPreferences()).clear()
+        handler.removeCallbacks(timeout)
+        handler.postDelayed(timeout, 60_000)
+        openPorter(showInstructions = true)
+    }
+
+    private fun openPorter(showInstructions: Boolean = false) {
+        try {
+            startActivity(Intent(this, MainActivity::class.java).apply {
+                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP)
+                putExtra(HomeActivity.EXTRA_SHOW_PAIRING_DIALOG, showInstructions)
+            })
+        } catch (e: Exception) {
+            Log.w("AdbPairingAccessibility", "Cannot open Porter", e)
         }
-        startActivity(intent)
-
-        handler.postDelayed({
-            Toast.makeText(this, getString(R.string.toast_pairing_timeout), Toast.LENGTH_LONG).show()
-            disableSelf()
-        }, 60_000)
     }
 
     override fun onAccessibilityEvent(event: AccessibilityEvent?) {
-        if (event == null) return
-        if (port != null && password != null) return
-
-        if ((event.contentChangeTypes and AccessibilityEvent.CONTENT_CHANGE_TYPE_TEXT) == 0) return
-        val text = event.source?.text ?: return
-
-        val ipPortRegex = Regex("""(?:\d{1,3}\.){3}\d{1,3}:(\d{2,5})""")
-        val passwordRegex = Regex("""\d{6}""")
-
-        ipPortRegex.matchEntire(text)
-            ?.groupValues
-            ?.get(1)
-            ?.toIntOrNull()
-            ?.let { port = it }
-        passwordRegex.matchEntire(text)
-            ?.value
-            ?.let { password = it }
-
-        if (port != null && password != null) {
-            val port = port!!
-            val password = password!!
-
-            var toastMsg = getString(R.string.notification_adb_pairing_failed_title)
-            GlobalScope.launch(Dispatchers.IO) {
-                val host = "127.0.0.1"
-
-                val key = try {
-                    AdbKey(PreferenceAdbKeyStore(ShizukuSettings.getPreferences()), "shizuku")
-                } catch (e: Throwable) {
-                    toastMsg = getString(R.string.adb_error_key_store)
-                    return@launch
-                }
-
-                AdbPairingClient(host, port, password, key).runCatching {
-                    start()
-                }.onFailure {
-                    when (it) {
-                        is ConnectException -> toastMsg = getString(R.string.cannot_connect_port)
-                        is AdbInvalidPairingCodeException -> toastMsg = getString(R.string.paring_code_is_wrong)
-                        is AdbKeyException -> toastMsg = getString(R.string.adb_error_key_store)
-                    }
-                }.onSuccess {
-                    if (it) {
-                        toastMsg = "${getString(R.string.notification_adb_pairing_succeed_title)}. ${getString(R.string.notification_adb_pairing_succeed_text)}"
-                   
-                        val intent = Intent(this@AdbPairingAccessibilityService, MainActivity::class.java).apply {
-                            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP)
-                        }
-                        startActivity(intent)
-                    }
-                }
-                withContext(Dispatchers.Main) {
-                    Toast.makeText(this@AdbPairingAccessibilityService, toastMsg, Toast.LENGTH_LONG).show()
-                }
-                disableSelf()
+        if (event == null || pairing || finished) return
+        val root = rootInActiveWindow ?: event.source ?: return
+        val credentials = readPairingCredentials(root) ?: return
+        pairing = true
+        handler.removeCallbacks(timeout)
+        scope.launch {
+            try {
+                pair(credentials.host, credentials.port, credentials.code)
+                coroutineContext.ensureActive()
+                finishPairing(true, getString(R.string.notification_adb_pairing_succeed_text))
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                coroutineContext.ensureActive()
+                Log.w("AdbPairingAccessibility", "Pairing failed", e)
+                finishPairing(false, pairingFailureMessage(e))
             }
         }
+    }
+
+    private fun finishPairing(success: Boolean, message: String) {
+        if (finished) return
+        finished = true
+        handler.removeCallbacks(timeout)
+        TvPairingResultStore(ShizukuSettings.getPreferences()).save(TvPairingResult(success, message))
+        openPorter()
+        disableSelf()
     }
 
     override fun onInterrupt() {}
 
     override fun onUnbind(intent: Intent?): Boolean {
         handler.removeCallbacksAndMessages(null)
+        scope.cancel()
         return super.onUnbind(intent)
     }
 
+    override fun onDestroy() {
+        handler.removeCallbacksAndMessages(null)
+        scope.cancel()
+        super.onDestroy()
+    }
+}
+
+internal data class PairingCredentials(val host: String, val port: Int, val code: String)
+
+internal fun readPairingCredentials(root: AccessibilityNodeInfo): PairingCredentials? {
+    var endpoint: Pair<String, Int>? = null
+    var code: String? = null
+    val address = Regex("((?:[0-9]{1,3}\\.){3}[0-9]{1,3}):([0-9]{2,5})")
+    fun visit(node: AccessibilityNodeInfo) {
+        val text = node.text?.toString()?.trim().orEmpty()
+        address.matchEntire(text)?.let { match ->
+            val port = match.groupValues[2].toIntOrNull()
+            if (port != null && port in 1..65535) endpoint = match.groupValues[1] to port
+        }
+        if (text.matches(Regex("[0-9]{6}"))) code = text
+        for (index in 0 until node.childCount) node.getChild(index)?.let { visit(it) }
+    }
+    visit(root)
+    val (host, port) = endpoint ?: return null
+    return PairingCredentials(host, port, code ?: return null)
 }

--- a/manager/src/main/java/moe/shizuku/manager/adb/AdbPairingClient.kt
+++ b/manager/src/main/java/moe/shizuku/manager/adb/AdbPairingClient.kt
@@ -8,6 +8,7 @@ import java.io.Closeable
 import java.io.DataInputStream
 import java.io.DataOutputStream
 import java.net.Socket
+import java.net.InetSocketAddress
 import java.nio.ByteBuffer
 import java.nio.ByteOrder
 import javax.net.ssl.SSLSocket
@@ -171,7 +172,7 @@ class AdbPairingClient(private val host: String, private val port: Int, private 
         Stopped
     }
 
-    private lateinit var socket: Socket
+    private val socket = Socket()
     private lateinit var inputStream: DataInputStream
     private lateinit var outputStream: DataOutputStream
 
@@ -201,11 +202,13 @@ class AdbPairingClient(private val host: String, private val port: Int, private 
     }
 
     private fun setupTlsConnection() {
-        socket = Socket(host, port)
+        socket.connect(InetSocketAddress(host, port), 10_000)
+        socket.soTimeout = 15_000
         socket.tcpNoDelay = true
 
         val sslContext = key.sslContext
         val sslSocket = sslContext.socketFactory.createSocket(socket, host, port, true) as SSLSocket
+        sslSocket.soTimeout = 15_000
         sslSocket.startHandshake()
         Log.d(TAG, "Handshake succeeded.")
 
@@ -285,6 +288,11 @@ class AdbPairingClient(private val host: String, private val port: Int, private 
         return true
     }
 
+    fun cancel() {
+        // Only interrupt I/O here; the pairing thread owns native-context cleanup.
+        runCatching { socket.close() }
+    }
+
     override fun close() {
         try {
             inputStream.close()
@@ -299,7 +307,7 @@ class AdbPairingClient(private val host: String, private val port: Int, private 
         } catch (e: Exception) {
         }
 
-        if (state != State.Ready) {
+        if (::pairingContext.isInitialized) {
             pairingContext.destroy()
         }
     }

--- a/manager/src/main/java/moe/shizuku/manager/adb/AdbPairingService.kt
+++ b/manager/src/main/java/moe/shizuku/manager/adb/AdbPairingService.kt
@@ -8,17 +8,19 @@ import android.content.pm.ServiceInfo
 import android.os.Build
 import android.os.IBinder
 import android.util.Log
-import android.widget.Toast
 import androidx.lifecycle.Observer
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 import moe.shizuku.manager.MainActivity
 import moe.shizuku.manager.R
-import moe.shizuku.manager.ShizukuSettings
 import moe.shizuku.manager.home.HomeActivity
 import rikka.core.ktx.unsafeLazy
-import java.net.ConnectException
 
 @TargetApi(Build.VERSION_CODES.R)
 class AdbPairingService : Service() {
@@ -57,28 +59,25 @@ class AdbPairingService : Service() {
     }
 
     private var adbMdns: AdbMdns? = null
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+    private var attempt: Job? = null
+    private var latestStartId = 0
+    internal var pair: suspend (String, Int, String) -> Unit = ::pairAdb
+
+    private val notifications get() = getSystemService(NotificationManager::class.java)
 
     private val observer = Observer<Pair<String, Int>> { (host, port) ->
-        Log.i(tag, "Pairing service host: $host, port: $port")
-        if (port <= 0) return@Observer
-
-        // Since the service could be killed before user finishing input,
-        // we need to put the host and port into Intent
-        val notification = createInputNotification(host, port)
-
-        getSystemService(NotificationManager::class.java).notify(NOTIFICATION_ID, notification)
+        if (adbMdns == null) return@Observer
+        invalidateReplyAction()
+        notifications.notify(NOTIFICATION_ID,
+            if (port > 0) createInputNotification(host, port) else searchingNotification)
     }
-
-    private var started = false
 
     override fun onCreate() {
         super.onCreate()
-
-        getSystemService(NotificationManager::class.java).createNotificationChannel(
-            NotificationChannel(
-                NOTIFICATION_CHANNEL,
-                getString(R.string.notification_channel_adb_pairing),
-                NotificationManager.IMPORTANCE_HIGH
+        notifications.createNotificationChannel(
+            NotificationChannel(NOTIFICATION_CHANNEL,
+                getString(R.string.notification_channel_adb_pairing), NotificationManager.IMPORTANCE_HIGH
             ).apply {
                 setSound(null, null)
                 setShowBadge(false)
@@ -87,151 +86,105 @@ class AdbPairingService : Service() {
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
-        val notification = when (intent?.action) {
+        latestStartId = startId
+        when (intent?.action) {
             startAction -> {
-                onStart()
+                reset()
+                notifications.cancel(NOTIFICATION_ID)
+                if (foreground(searchingNotification)) startSearch()
             }
             replyAction -> {
-                val code = RemoteInput.getResultsFromIntent(intent)?.getCharSequence(remoteInputResultKey) ?: ""
-                val host = intent.getStringExtra(hostKey) ?: "127.0.0.1"
-                val port = intent.getIntExtra(portKey, -1)
-                if (port != -1) {
-                    onInput(code.toString(), host, port)
-                } else {
-                    onStart()
+                reset()
+                if (foreground(workingNotification)) {
+                    val code = RemoteInput.getResultsFromIntent(intent)
+                        ?.getCharSequence(remoteInputResultKey)?.toString().orEmpty().trim()
+                    val host = intent.getStringExtra(hostKey) ?: "127.0.0.1"
+                    val port = intent.getIntExtra(portKey, -1)
+                    attempt = scope.launch {
+                        try {
+                            if (port !in 1..65535 || !code.matches(Regex("[0-9]{6}"))) {
+                                throw AdbInvalidPairingCodeException()
+                            }
+                            pair(host, port, code)
+                            coroutineContext.ensureActive()
+                            handleResult(true, null)
+                        } catch (e: CancellationException) {
+                            throw e
+                        } catch (e: Exception) {
+                            coroutineContext.ensureActive()
+                            Log.w(tag, "Pair failed", e)
+                            handleResult(false, pairingFailureMessage(e))
+                        }
+                    }
                 }
             }
             stopAction -> {
+                reset()
                 stopForeground(STOP_FOREGROUND_REMOVE)
                 stopSelf()
-                null
             }
-            else -> {
-                return START_NOT_STICKY
-            }
+            else -> stopSelf()
         }
-        if (notification != null) {
-            try {
-                startForeground(NOTIFICATION_ID, notification,
-                    ServiceInfo.FOREGROUND_SERVICE_TYPE_MANIFEST)
-            } catch (e: Throwable) {
-                Log.e(tag, "startForeground failed", e)
+        // A remote reply contains a single-use code; never replay it after process death.
+        return START_NOT_STICKY
+    }
 
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S
-                    && e is ForegroundServiceStartNotAllowedException) {
-                    getSystemService(NotificationManager::class.java).notify(NOTIFICATION_ID, notification)
-                }
-            }
-        }
-        return START_REDELIVER_INTENT
+    private fun foreground(notification: Notification): Boolean = try {
+        startForeground(NOTIFICATION_ID, notification, ServiceInfo.FOREGROUND_SERVICE_TYPE_MANIFEST)
+        true
+    } catch (e: Exception) {
+        Log.e(tag, "startForeground failed", e)
+        handleResult(false, getString(R.string.porter_pairing_failed_retry))
+        false
     }
 
     override fun onTimeout(startId: Int) {
-        Toast.makeText(this, R.string.toast_pairing_timeout, Toast.LENGTH_SHORT).show()
-        stopForeground(STOP_FOREGROUND_REMOVE)
-        stopSelf()
+        reset()
+        handleResult(false, getString(R.string.porter_pairing_notification_timeout))
     }
 
     private fun startSearch() {
-        if (started) return
-        started = true
-        adbMdns = AdbMdns(this, AdbMdns.TLS_PAIRING, observer).apply { start() }
+        val discovery = AdbMdns(this, AdbMdns.TLS_PAIRING, observer)
+        adbMdns = discovery
+        discovery.start()
     }
 
-    private fun stopSearch() {
-        if (!started) return
-        started = false
-        adbMdns?.stop()
+    private fun reset() {
+        attempt?.cancel()
+        attempt = null
+        val discovery = adbMdns
+        adbMdns = null
+        discovery?.stop()
+        invalidateReplyAction()
     }
 
     override fun onDestroy() {
+        reset()
+        scope.cancel()
         super.onDestroy()
-        stopSearch()
     }
 
-    private fun onStart(): Notification {
-        startSearch()
-        return searchingNotification
-    }
-
-    private fun onInput(code: String, host: String, port: Int): Notification {
-        GlobalScope.launch(Dispatchers.IO) {
-            val key = try {
-                AdbKey(PreferenceAdbKeyStore(ShizukuSettings.getPreferences()), "shizuku")
-            } catch (e: Throwable) {
-                e.printStackTrace()
-                return@launch
-            }
-
-            AdbPairingClient(host, port, code, key).runCatching {
-                start()
-            }.onFailure {
-                handleResult(false, it)
-            }.onSuccess {
-                handleResult(it, null)
-            }
-        }
-
-        return workingNotification
-    }
-
-    private fun handleResult(success: Boolean, exception: Throwable?) {
+    private fun handleResult(success: Boolean, message: String?) {
         stopForeground(STOP_FOREGROUND_DETACH)
-
-        val title: String
-        val text: String?
-
-        if (success) {
-            Log.i(tag, "Pair succeed")
-
-            title = getString(R.string.notification_adb_pairing_succeed_title)
-            text = getString(R.string.notification_adb_pairing_succeed_text)
-
-            stopSearch()
-        } else {
-            title = getString(R.string.notification_adb_pairing_failed_title)
-
-            text = when (exception) {
-                is ConnectException -> {
-                    getString(R.string.cannot_connect_port)
-                }
-                is AdbInvalidPairingCodeException -> {
-                    getString(R.string.paring_code_is_wrong)
-                }
-                is AdbKeyException -> {
-                    getString(R.string.adb_error_key_store)
-                }
-                else -> {
-                    exception?.let { Log.getStackTraceString(it) }
-                }
-            }
-
-            if (exception != null) {
-                Log.w(tag, "Pair failed", exception)
-            } else {
-                Log.w(tag, "Pair failed")
-            }
-        }
-
-        getSystemService(NotificationManager::class.java).notify(
-            NOTIFICATION_ID,
+        notifications.notify(NOTIFICATION_ID,
             Notification.Builder(this, NOTIFICATION_CHANNEL)
                 .setColor(getColor(R.color.notification))
                 .setSmallIcon(R.drawable.ic_system_icon)
-                .setContentTitle(title)
-                .setContentText(text)
-                .apply {
-                    if (!success) {
-                        addAction(retryNotificationAction)
-                    } else {
-                        setContentIntent(launchPendingIntent)
-                        addAction(startNotificationAction)
-                        setAutoCancel(true)
-                    }
-                }
-                .build()
-        )
-        stopSelf()
+                .setContentTitle(getString(if (success) R.string.notification_adb_pairing_succeed_title
+                    else R.string.notification_adb_pairing_failed_title))
+                .setContentText(message ?: getString(R.string.notification_adb_pairing_succeed_text))
+                .setStyle(Notification.BigTextStyle().bigText(message
+                    ?: getString(R.string.notification_adb_pairing_succeed_text)))
+                .setContentIntent(if (success) launchPendingIntent else retryTutorialPendingIntent)
+                .addAction(if (success) startNotificationAction else retryNotificationAction)
+                .setAutoCancel(true)
+                .build())
+        stopSelf(latestStartId)
+    }
+
+    private val retryTutorialPendingIntent by unsafeLazy {
+        PendingIntent.getActivity(this, retryRequestId, Intent(this, AdbPairingTutorialActivity::class.java),
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE)
     }
 
     private val launchIntent by unsafeLazy {
@@ -286,7 +239,7 @@ class AdbPairingService : Service() {
     }
 
     private val retryNotificationAction by unsafeLazy {
-        val pendingIntent = PendingIntent.getService(
+        val pendingIntent = PendingIntent.getForegroundService(
             this,
             retryRequestId,
             startIntent(this),
@@ -304,46 +257,19 @@ class AdbPairingService : Service() {
             .build()
     }
 
-    private val replyNotificationAction by unsafeLazy {
-        val remoteInput = RemoteInput.Builder(remoteInputResultKey).run {
-            setLabel(getString(R.string.dialog_adb_pairing_paring_code))
-            build()
-        }
-
-        val pendingIntent = PendingIntent.getForegroundService(
-            this,
-            replyRequestId,
-            replyIntent(this, "127.0.0.1", -1),
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S)
-                PendingIntent.FLAG_MUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
-            else
-                PendingIntent.FLAG_UPDATE_CURRENT
-        )
-
-        Notification.Action.Builder(
-            null,
-            getString(R.string.notification_adb_pairing_input_paring_code),
-            pendingIntent
-        )
-            .addRemoteInput(remoteInput)
-            .build()
+    private fun invalidateReplyAction() {
+        PendingIntent.getForegroundService(this, replyRequestId, replyIntent(this, "", -1),
+            PendingIntent.FLAG_NO_CREATE or PendingIntent.FLAG_MUTABLE)?.cancel()
     }
 
     private fun replyNotificationAction(host: String, port: Int): Notification.Action {
-        // Ensure pending intent is created
-        val action = replyNotificationAction
-
-        PendingIntent.getForegroundService(
-            this,
-            replyRequestId,
-            replyIntent(this, host, port),
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S)
-                PendingIntent.FLAG_MUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
-            else
-                PendingIntent.FLAG_UPDATE_CURRENT
-        )
-
-        return action
+        val pendingIntent = PendingIntent.getForegroundService(this, replyRequestId,
+            replyIntent(this, host, port), PendingIntent.FLAG_CANCEL_CURRENT or PendingIntent.FLAG_MUTABLE)
+        return Notification.Action.Builder(null,
+            getString(R.string.notification_adb_pairing_input_paring_code), pendingIntent)
+            .addRemoteInput(RemoteInput.Builder(remoteInputResultKey)
+                .setLabel(getString(R.string.dialog_adb_pairing_paring_code)).build())
+            .build()
     }
 
     private val searchingNotification by unsafeLazy {
@@ -361,6 +287,7 @@ class AdbPairingService : Service() {
             .setContentTitle(getString(R.string.notification_adb_pairing_service_found_title))
             .setSmallIcon(R.drawable.ic_system_icon)
             .addAction(replyNotificationAction(host, port))
+            .addAction(stopNotificationAction)
             .build()
     }
 
@@ -368,6 +295,7 @@ class AdbPairingService : Service() {
         Notification.Builder(this, NOTIFICATION_CHANNEL)
             .setColor(getColor(R.color.notification))
             .setContentTitle(getString(R.string.notification_adb_pairing_working_title))
+            .addAction(stopNotificationAction)
             .setSmallIcon(R.drawable.ic_system_icon)
             .build()
     }

--- a/manager/src/main/java/moe/shizuku/manager/adb/AdbPairingTutorialActivity.kt
+++ b/manager/src/main/java/moe/shizuku/manager/adb/AdbPairingTutorialActivity.kt
@@ -39,7 +39,7 @@ class AdbPairingTutorialActivity : ComposeActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         notificationEnabled = isNotificationEnabled()
-        if (notificationEnabled) startPairingService()
+        if (notificationEnabled && savedInstanceState == null) startPairingService()
         porterContent {
             PorterScaffold(stringResource(R.string.adb_pairing), onBack = { finish() }) { padding ->
                 Column(Modifier.padding(padding).consumeWindowInsets(padding).verticalScroll(rememberScrollState()).padding(24.dp), verticalArrangement = Arrangement.spacedBy(16.dp)) {
@@ -60,6 +60,10 @@ class AdbPairingTutorialActivity : ComposeActivity() {
                         Button(onClick = { SettingsHelper.launchOrHighlightWirelessDebugging(this@AdbPairingTutorialActivity) }) { Text(stringResource(R.string.development_settings)) }
                         HtmlText(stringResource(R.string.adb_pairing_tutorial_content_enter_pairing_code))
                         HtmlText(stringResource(R.string.adb_pairing_tutorial_content_finish))
+                        Text(stringResource(R.string.porter_pairing_retry_instructions))
+                        OutlinedButton(onClick = { startPairingService() }) {
+                            Text(stringResource(R.string.porter_pairing_restart))
+                        }
                     }
                 }
             }

--- a/manager/src/main/java/moe/shizuku/manager/adb/AdbStarter.kt
+++ b/manager/src/main/java/moe/shizuku/manager/adb/AdbStarter.kt
@@ -20,7 +20,7 @@ object AdbStarter {
         log?.invoke("Starting with wireless adb...\n")
 
         withContext(Dispatchers.IO) {
-            val key = runCatching { AdbKey(PreferenceAdbKeyStore(ShizukuSettings.getPreferences()), "shizuku") }
+            val key = runCatching { AdbKey(PreferenceAdbKeyStore(ShizukuSettings.getPreferences())) }
                 .getOrElse {
                     if (it is CancellationException) throw it
                     else throw AdbKeyException(it)

--- a/manager/src/main/java/moe/shizuku/manager/adb/TvPairingResult.kt
+++ b/manager/src/main/java/moe/shizuku/manager/adb/TvPairingResult.kt
@@ -1,0 +1,23 @@
+package moe.shizuku.manager.adb
+
+import android.content.SharedPreferences
+import androidx.core.content.edit
+
+internal data class TvPairingResult(val success: Boolean, val message: String)
+
+internal class TvPairingResultStore(private val preferences: SharedPreferences) {
+    fun read(): TvPairingResult? {
+        val message = preferences.getString("tv_pairing_result_message", null) ?: return null
+        return TvPairingResult(preferences.getBoolean("tv_pairing_result_success", false), message)
+    }
+
+    fun save(result: TvPairingResult) = preferences.edit {
+        putBoolean("tv_pairing_result_success", result.success)
+        putString("tv_pairing_result_message", result.message)
+    }
+
+    fun clear() = preferences.edit {
+        remove("tv_pairing_result_success")
+        remove("tv_pairing_result_message")
+    }
+}

--- a/manager/src/main/java/moe/shizuku/manager/home/AdbPairDialogFragment.kt
+++ b/manager/src/main/java/moe/shizuku/manager/home/AdbPairDialogFragment.kt
@@ -16,12 +16,10 @@ import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.*
 import kotlinx.coroutines.flow.MutableStateFlow
 import moe.shizuku.manager.R
-import moe.shizuku.manager.ShizukuSettings
 import moe.shizuku.manager.adb.*
 import moe.shizuku.manager.ui.ComposeDialogFragment
 import moe.shizuku.manager.ui.LocalNetworkPermission
 import moe.shizuku.manager.utils.SettingsHelper
-import java.net.ConnectException
 
 class AdbPairDialogFragment : ComposeDialogFragment() {
     private val model: PairingViewModel by viewModels()
@@ -34,9 +32,11 @@ class AdbPairDialogFragment : ComposeDialogFragment() {
         val busy by model.busy.collectAsStateWithLifecycle()
         val error by model.error.collectAsStateWithLifecycle()
         val success by model.success.collectAsStateWithLifecycle()
-        var code by rememberSaveable { mutableStateOf("") }
-        var port by rememberSaveable { mutableStateOf("") }
-        LaunchedEffect(endpoint) { if (endpoint.second in 1..65535) port = endpoint.second.toString() }
+        var code by rememberSaveable(endpoint) { mutableStateOf("") }
+        var port by rememberSaveable(endpoint) {
+            mutableStateOf(if (endpoint.second in 1..65535) endpoint.second.toString() else "")
+        }
+        LaunchedEffect(error) { if (error != null) code = "" }
         LaunchedEffect(success) { if (success) dismissAllowingStateLoss() }
         val multi = requireActivity().isInMultiWindowMode || (requireActivity().window.decorView.display?.displayId ?: -1) > 0
         Text(stringResource(if (endpoint.second > 0) R.string.dialog_adb_pairing_title else R.string.dialog_adb_pairing_discovery), style = MaterialTheme.typography.headlineSmall)
@@ -49,16 +49,14 @@ class AdbPairDialogFragment : ComposeDialogFragment() {
             label = { Text(stringResource(R.string.dialog_adb_port)) }, singleLine = true, keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number))
         OutlinedTextField(code, { code = it.take(6); model.error.value = null }, Modifier.fillMaxWidth(), enabled = !busy,
             label = { Text(stringResource(R.string.dialog_adb_pairing_paring_code)) }, singleLine = true, keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number))
-        error?.let { failure -> Text(when (failure) {
-            is ConnectException -> stringResource(R.string.cannot_connect_port)
-            is AdbInvalidPairingCodeException -> stringResource(R.string.paring_code_is_wrong)
-            is AdbKeyException -> stringResource(R.string.adb_error_key_store)
-            else -> failure.localizedMessage ?: failure.javaClass.simpleName
-        }, color = MaterialTheme.colorScheme.error) }
+        error?.let { Text(requireContext().pairingFailureMessage(it), color = MaterialTheme.colorScheme.error) }
         if (busy) LinearProgressIndicator()
         TextButton(enabled = !busy, onClick = { SettingsHelper.launchOrHighlightWirelessDebugging(requireContext()) }) { Text(stringResource(R.string.development_settings)) }
         Button(enabled = !busy && port.toIntOrNull()?.let { it in 1..65535 } == true && code.length == 6,
             onClick = { model.pair(port.toInt(), code) }) { Text(stringResource(android.R.string.ok)) }
+        TextButton(enabled = !busy, onClick = { code = ""; port = ""; model.restartDiscovery() }) {
+            Text(stringResource(R.string.porter_pairing_restart))
+        }
         TextButton(onClick = { dismissAllowingStateLoss() }) { Text(stringResource(android.R.string.cancel)) }
     }
 }
@@ -71,6 +69,13 @@ class PairingViewModel(application: Application) : AndroidViewModel(application)
     private val mdns = AdbMdns(application, AdbMdns.TLS_PAIRING) { endpoint.value = it }
     private var discovering = false
     fun startDiscovery() { if (!discovering) { discovering = true; mdns.start() } }
+    fun restartDiscovery() {
+        mdns.stop()
+        discovering = false
+        endpoint.value = "127.0.0.1" to -1
+        error.value = null
+        startDiscovery()
+    }
     fun pair(port: Int, password: String) {
         if (busy.value) return
         val host = endpoint.value.first
@@ -78,14 +83,7 @@ class PairingViewModel(application: Application) : AndroidViewModel(application)
         error.value = null
         viewModelScope.launch {
             try {
-                // Finish an accepted pairing attempt even when its dialog is dismissed.
-                withContext(NonCancellable + Dispatchers.IO) {
-                    val key = try { AdbKey(PreferenceAdbKeyStore(ShizukuSettings.getPreferences()), "shizuku") }
-                    catch (e: Exception) { throw AdbKeyException(e) }
-                    AdbPairingClient(host, port, password, key).use { client ->
-                        if (!client.start()) throw AdbInvalidPairingCodeException()
-                    }
-                }
+                pairAdb(host.ifEmpty { "127.0.0.1" }, port, password)
                 success.value = true
             } catch (e: CancellationException) { throw e }
             catch (e: Exception) { error.value = e }

--- a/manager/src/main/java/moe/shizuku/manager/home/HomeActivity.kt
+++ b/manager/src/main/java/moe/shizuku/manager/home/HomeActivity.kt
@@ -20,6 +20,7 @@ import moe.shizuku.manager.BuildConfig
 import moe.shizuku.manager.R
 import moe.shizuku.manager.Helps
 import moe.shizuku.manager.ShizukuSettings
+import moe.shizuku.manager.adb.TvPairingResultStore
 import moe.shizuku.manager.adb.AdbPairingService
 import moe.shizuku.manager.management.AppsViewModel
 import moe.shizuku.manager.management.ApplicationManagementActivity
@@ -46,10 +47,6 @@ abstract class HomeActivity : ComposeActivity() {
     }
 
     private fun consumeIntent(intent: Intent) {
-        if (intent.getBooleanExtra(EXTRA_SHOW_PAIRING_DIALOG, false)) {
-            intent.removeExtra(EXTRA_SHOW_PAIRING_DIALOG)
-            showAccessibilityDialog()
-        }
         if (intent.getBooleanExtra(EXTRA_START_SERVICE_VIA_WADB, false)) {
             intent.removeExtra(EXTRA_START_SERVICE_VIA_WADB)
             getSystemService(NotificationManager::class.java).cancel(AdbPairingService.NOTIFICATION_ID)
@@ -62,6 +59,20 @@ abstract class HomeActivity : ComposeActivity() {
         homeModel.reload()
         homeModel.checkBatteryOptimization()
         appsModel.load()
+    }
+
+    override fun onPostResume() {
+        super.onPostResume()
+        val result = TvPairingResultStore(ShizukuSettings.getPreferences()).read()
+        if (result != null) {
+            (supportFragmentManager.findFragmentByTag(AccessibilityDialogFragment::class.java.simpleName)
+                as? AccessibilityDialogFragment)?.dismiss()
+            intent.removeExtra(EXTRA_SHOW_PAIRING_DIALOG)
+            TvPairingResultDialogFragment.create(result).show(supportFragmentManager)
+        } else if (intent.getBooleanExtra(EXTRA_SHOW_PAIRING_DIALOG, false)) {
+            intent.removeExtra(EXTRA_SHOW_PAIRING_DIALOG)
+            showAccessibilityDialog()
+        }
     }
 
     @Composable

--- a/manager/src/main/java/moe/shizuku/manager/home/TvPairingResultDialogFragment.kt
+++ b/manager/src/main/java/moe/shizuku/manager/home/TvPairingResultDialogFragment.kt
@@ -1,0 +1,48 @@
+package moe.shizuku.manager.home
+
+import android.os.Bundle
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
+import androidx.lifecycle.lifecycleScope
+import moe.shizuku.manager.R
+import moe.shizuku.manager.ShizukuSettings
+import moe.shizuku.manager.adb.TvPairingResult
+import moe.shizuku.manager.adb.TvPairingResultStore
+import moe.shizuku.manager.ui.ComposeDialogFragment
+
+class TvPairingResultDialogFragment : ComposeDialogFragment() {
+    @Composable override fun Content() {
+        val success = requireArguments().getBoolean("success")
+        TvPairingResultContent(success, requireArguments().getString("message").orEmpty(),
+            onAction = {
+                TvPairingResultStore(ShizukuSettings.getPreferences()).clear()
+                dismissAllowingStateLoss()
+                if (success) WirelessStart.start(requireActivity(), requireActivity().lifecycleScope)
+                else WirelessStart.pair(requireContext())
+            }, onClose = {
+                TvPairingResultStore(ShizukuSettings.getPreferences()).clear()
+                dismissAllowingStateLoss()
+            })
+    }
+
+    companion object {
+        internal fun create(result: TvPairingResult) = TvPairingResultDialogFragment().apply {
+            arguments = Bundle().apply {
+                putBoolean("success", result.success)
+                putString("message", result.message)
+            }
+        }
+    }
+}
+
+@Composable
+internal fun TvPairingResultContent(success: Boolean, message: String, onAction: () -> Unit, onClose: () -> Unit) {
+    Text(stringResource(if (success) R.string.notification_adb_pairing_succeed_title
+        else R.string.notification_adb_pairing_failed_title), style = MaterialTheme.typography.headlineSmall)
+    Text(message)
+    Button(onClick = onAction) {
+        Text(stringResource(if (success) R.string.home_root_button_start else R.string.notification_adb_pairing_retry))
+    }
+    TextButton(onClick = onClose) { Text(stringResource(android.R.string.ok)) }
+}

--- a/manager/src/main/res/values-de/strings.xml
+++ b/manager/src/main/res/values-de/strings.xml
@@ -31,7 +31,7 @@
     <string name="dialog_wireless_adb_not_enabled">Debugging über WLAN ist nicht aktiviert.\nHinweis: Vor Android 11 ist zum Aktivieren von Debugging über WLAN eine Verbindung mit einem Computer erforderlich.</string>
     <string name="dialog_usb_debugging_not_enabled">USB-Debugging ist nicht aktiviert.\nBitte aktiviere es in den \"Entwickleroptionen\".</string>
     <string name="dialog_adb_pairing_accessibility_permission">Unter Android 14 widerruft das Installieren/Aktualisieren von Porter über den Paketinstaller die Berechtigung ^1, die zum Aktivieren der Bedienungshilfe für die Kopplung benötigt wird.\n\nFühre zum Erteilen folgenden ADB-Befehl aus:\n\n^2\n\nNach dem Ausführen des Befehls kannst du mit der Kopplung fortfahren.\n\nHinweis: Du kannst das umgehen, indem du Porter über ADB installierst/aktualisierst.</string>
-    <string name="dialog_adb_pairing_accessibility_enable">Bitte aktiviere die Bedienungshilfe, um die Kopplung zu starten. Dadurch kann Porter den Kopplungscode erkennen.\n\nDie Bedienungshilfe wird ausgeschaltet, sobald der Code gefunden wurde oder nach 1 Minute, um Energie zu sparen.</string>
+    <string name="dialog_adb_pairing_accessibility_enable">Aktiviere den Bedienungshilfedienst, um die Kopplung zu starten. Damit kann Porter den Kopplungscode erkennen.\n\nDer Dienst wird nach dem Kopplungsversuch ausgeschaltet oder wenn innerhalb einer Minute kein Code gefunden wurde. Porter zeigt das Ergebnis an und bietet einen erneuten Versuch an.</string>
     <string name="dialog_adb_pairing_accessibility_navigate">Bitte starte die Kopplung mit folgenden Schritten:\n- Öffne die \"Entwickleroptionen\"\n- Aktiviere \"USB-Debugging\" und \"Debugging über WLAN\"\n- Tippe links auf \"Debugging über WLAN\"\n- Tippe auf \"Gerät mit Kopplungscode koppeln\". Porter erkennt den Kopplungscode automatisch.</string>
     <string name="adb_pairing_requires_multi_window">Bitte wechsle zuerst in den Splitscreen-Modus (Mehrfenstermodus).</string>
     <string name="adb_pairing_requires_multi_window_reason">Das System verlangt, dass der Kopplungsdialog immer sichtbar ist. Nur im Splitscreen-Modus können diese App und der Systemdialog gleichzeitig sichtbar sein.</string>
@@ -205,4 +205,10 @@
     <string name="porter_license_porter">Porter und die ursprüngliche Shizuku-App · Apache-Lizenz 2.0</string>
     <string name="porter_license_api">Shizuku-API und ihr Porter-Fork · MIT-Lizenz</string>
     <string name="porter_license_notice">Urheberrechts- und Quellenhinweise</string>
+    <string name="porter_pairing_restart">Kopplung neu starten</string>
+    <string name="porter_pairing_retry_instructions">Wenn ein Code abgelehnt wurde oder die Benachrichtigung verschwunden ist, starte die Kopplung hier neu. Schließe danach Androids alten Kopplungscode-Dialog und öffne einen neuen. Verwende den neuen Code; Porters App-Daten musst du nicht löschen.</string>
+    <string name="porter_pairing_search_timeout">Innerhalb einer Minute wurde kein Kopplungscode empfangen. Die Kopplung wurde beendet. Wähle „Erneut versuchen“ und öffne in den Einstellungen für drahtloses Debugging einen neuen Kopplungscode-Dialog.</string>
+    <string name="porter_pairing_attempt_timeout">Zeitüberschreitung bei der Kopplungsverbindung. Öffne in den Einstellungen für drahtloses Debugging einen neuen Kopplungscode-Dialog und versuche es erneut.</string>
+    <string name="porter_pairing_failed_retry">Kopplung fehlgeschlagen. Öffne in den Einstellungen für drahtloses Debugging einen neuen Kopplungscode-Dialog und versuche es erneut.</string>
+    <string name="porter_pairing_notification_timeout">Die Kopplung wurde beendet, weil die Benachrichtigung abgelaufen ist. Wähle „Erneut versuchen“ und öffne in den Einstellungen für drahtloses Debugging einen neuen Kopplungscode-Dialog.</string>
 </resources>

--- a/manager/src/main/res/values/strings.xml
+++ b/manager/src/main/res/values/strings.xml
@@ -32,7 +32,7 @@
     <string name="dialog_wireless_adb_not_enabled">Wireless debugging is not enabled.\nNote, before Android 11, to enable wireless debugging, computer connection is a must.</string>
     <string name="dialog_usb_debugging_not_enabled">USB debugging is not enabled.\nPlease enable it in \"Developer Options\".</string>
     <string name="dialog_adb_pairing_accessibility_permission">On Android 14, installing/updating Porter with the Package Installer revokes the ^1 permission, which is required to enable the accessibility service for pairing.\n\nTo grant it, run the following ADB command:\n\n^2\n\nAfter running the command, you may continue with the pairing process.\n\nNote: you can bypass this by installing/updating Porter with ADB.</string>
-    <string name="dialog_adb_pairing_accessibility_enable">Please enable the accessibility service to start the pairing process. This allows Porter to detect the pairing code.\n\nThe accessibility service will be turned off when the code is found or after 1 minute to save energy.</string>
+    <string name="dialog_adb_pairing_accessibility_enable">Please enable the accessibility service to start the pairing process. This allows Porter to detect the pairing code.\n\nThe accessibility service will turn off after the pairing attempt, or if no code is found within one minute. Porter will show the result and let you retry.</string>
     <string name="dialog_adb_pairing_accessibility_navigate">Please start pairing by performing the following steps:\n- Navigate to \"Developer Options\"\n- Enable \"USB debugging\" and \"Wireless debugging\"\n- Tap the left side of \"Wireless debugging\"\n- Tap \"Pair device with pairing code.\" Porter will automatically detect the pairing code.</string>
     <string name="adb_pairing_requires_multi_window">Please enter split-screen (multi-window) mode first.</string>
     <string name="adb_pairing_requires_multi_window_reason">The system requires the pairing dialog to always be visible. Using split-screen mode is the only way to let this app and the system dialog be visible at the same time.</string>
@@ -208,4 +208,10 @@
     <string name="porter_license_porter">Porter and the original Shizuku application · Apache License 2.0</string>
     <string name="porter_license_api">Shizuku API and its Porter fork · MIT License</string>
     <string name="porter_license_notice">Copyright and attribution notices</string>
+    <string name="porter_pairing_restart">Restart pairing</string>
+    <string name="porter_pairing_retry_instructions">If a code was rejected or the notification disappeared, restart pairing here. Then close Android’s old pairing-code dialog and open a new one. Use the new code; you do not need to clear Porter’s data.</string>
+    <string name="porter_pairing_search_timeout">No pairing code was received within one minute. Pairing has stopped. Choose Retry, then open a new pairing-code dialog in Wireless debugging.</string>
+    <string name="porter_pairing_attempt_timeout">The pairing connection timed out. Open a new pairing-code dialog in Wireless debugging and try again.</string>
+    <string name="porter_pairing_failed_retry">Pairing failed. Open a new pairing-code dialog in Wireless debugging and try again.</string>
+    <string name="porter_pairing_notification_timeout">Pairing has stopped because the notification timed out. Choose Retry, then open a new pairing-code dialog in Wireless debugging.</string>
 </resources>

--- a/manager/src/test/java/moe/shizuku/manager/adb/AdbMdnsTest.kt
+++ b/manager/src/test/java/moe/shizuku/manager/adb/AdbMdnsTest.kt
@@ -1,0 +1,94 @@
+package moe.shizuku.manager.adb
+
+import android.content.Context
+import android.net.nsd.NsdManager
+import android.net.nsd.NsdServiceInfo
+import android.os.Looper
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Assert.*
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import java.net.InetAddress
+import java.net.ServerSocket
+
+@RunWith(RobolectricTestRunner::class)
+class AdbMdnsTest {
+    private val context = ApplicationProvider.getApplicationContext<Context>()
+    private val nsd = shadowOf(context.getSystemService(NsdManager::class.java))
+    private fun idle() = shadowOf(Looper.getMainLooper()).idle()
+
+    private fun await(check: () -> Boolean) {
+        val deadline = System.nanoTime() + 3_000_000_000L
+        while (!check() && System.nanoTime() < deadline) { idle(); Thread.sleep(10) }
+        assertTrue("Callback did not arrive", check())
+    }
+
+    @Test fun stopBeforeRegistrationAndRestartCannotReviveOldListener() {
+        val results = mutableListOf<Pair<String, Int>>()
+        val mdns = AdbMdns(context, AdbMdns.TLS_PAIRING) { results += it }
+        mdns.start()
+        val old = nsd.getDiscoveryListeners(AdbMdns.TLS_PAIRING)!!.single()
+        mdns.stop()
+        mdns.start()
+        val current = nsd.getDiscoveryListeners(AdbMdns.TLS_PAIRING)!!.last()
+        old.onDiscoveryStarted(AdbMdns.TLS_PAIRING)
+        idle()
+        assertNull(nsd.getDiscoveryListenerServiceType(old))
+        assertEquals(AdbMdns.TLS_PAIRING, nsd.getDiscoveryListenerServiceType(current))
+        old.onDiscoveryStopped(AdbMdns.TLS_PAIRING)
+        old.onServiceFound(NsdServiceInfo().apply { serviceName = "old" })
+        idle()
+        assertTrue(results.isEmpty())
+        assertEquals(AdbMdns.TLS_PAIRING, nsd.getDiscoveryListenerServiceType(current))
+        mdns.stop()
+    }
+
+    @Test fun lateResolutionOfLostServiceIsIgnoredForPairingAndStartup() {
+        for (type in listOf(AdbMdns.TLS_PAIRING, AdbMdns.TLS_CONNECT)) {
+            val results = mutableListOf<Pair<String, Int>>()
+            val mdns = AdbMdns(context, type) { results += it }
+            mdns.start()
+            val listener = nsd.getDiscoveryListeners(type)!!.single()
+            listener.onDiscoveryStarted(type)
+            ServerSocket(0, 1, InetAddress.getLoopbackAddress()).use { socket ->
+                val info = NsdServiceInfo().apply {
+                    serviceName = "adb-test"
+                    serviceType = type
+                    host = InetAddress.getLoopbackAddress()
+                    port = socket.localPort
+                }
+                listener.onServiceFound(info)
+                idle()
+                val resolution = nsd.getResolveListeners(info)!!.single()
+                listener.onServiceLost(info)
+                idle()
+                resolution.onServiceResolved(info)
+                idle()
+                assertTrue(results.isEmpty())
+                listener.onServiceFound(info)
+                idle()
+                nsd.getResolveListeners(info)!!.last().onServiceResolved(info)
+                idle()
+                await { results.isNotEmpty() }
+                assertEquals(listOf("127.0.0.1" to socket.localPort), results)
+                listener.onServiceLost(info)
+                idle()
+                assertEquals("" to -1, results.last())
+            }
+            mdns.stop()
+        }
+    }
+
+    @Test fun discoveryFailureAllowsAnotherStart() {
+        val mdns = AdbMdns(context, AdbMdns.TLS_PAIRING) {}
+        mdns.start()
+        val old = nsd.getDiscoveryListeners(AdbMdns.TLS_PAIRING)!!.single()
+        old.onStartDiscoveryFailed(AdbMdns.TLS_PAIRING, NsdManager.FAILURE_INTERNAL_ERROR)
+        idle()
+        mdns.start()
+        assertNotSame(old, nsd.getDiscoveryListeners(AdbMdns.TLS_PAIRING)!!.last())
+        mdns.stop()
+    }
+}

--- a/manager/src/test/java/moe/shizuku/manager/adb/AdbPairingServiceTest.kt
+++ b/manager/src/test/java/moe/shizuku/manager/adb/AdbPairingServiceTest.kt
@@ -1,0 +1,128 @@
+package moe.shizuku.manager.adb
+
+import android.app.Notification
+import android.app.NotificationManager
+import android.app.RemoteInput
+import android.content.Context
+import android.content.Intent
+import android.net.nsd.NsdManager
+import android.net.nsd.NsdServiceInfo
+import android.os.Bundle
+import android.os.Looper
+import androidx.test.core.app.ApplicationProvider
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import moe.shizuku.manager.R
+import org.junit.After
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.android.controller.ServiceController
+import java.net.InetAddress
+import java.net.ServerSocket
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+class AdbPairingServiceTest {
+    private val dispatcher = StandardTestDispatcher()
+    private val context = ApplicationProvider.getApplicationContext<Context>()
+    private lateinit var controller: ServiceController<AdbPairingService>
+    private val service get() = controller.get()
+    private val notifications = shadowOf(context.getSystemService(NotificationManager::class.java))
+    private val nsd = shadowOf(context.getSystemService(NsdManager::class.java))
+    private val notification get() = notifications.getNotification(AdbPairingService.NOTIFICATION_ID)
+    private fun idle() { shadowOf(Looper.getMainLooper()).idle(); dispatcher.scheduler.runCurrent() }
+    private fun title() = notification.extras.getCharSequence(Notification.EXTRA_TITLE).toString()
+
+    @Before fun setup() {
+        Dispatchers.setMain(dispatcher)
+        controller = Robolectric.buildService(AdbPairingService::class.java).create()
+    }
+    @After fun cleanup() { controller.destroy(); Dispatchers.resetMain() }
+    private fun start() { service.onStartCommand(AdbPairingService.startIntent(context), 0, 1); idle() }
+    private fun reply(code: String) {
+        val intent = Intent(context, AdbPairingService::class.java).setAction("reply")
+            .putExtra("pairing_host", "127.0.0.1").putExtra("paring_code", 37123)
+        RemoteInput.addResultsToIntent(arrayOf(RemoteInput.Builder("paring_code").build()), intent,
+            Bundle().apply { putCharSequence("paring_code", code) })
+        service.onStartCommand(intent, 0, 2)
+        idle()
+    }
+
+    private fun await(check: () -> Boolean) {
+        val deadline = System.nanoTime() + 3_000_000_000L
+        while (!check() && System.nanoTime() < deadline) { idle(); Thread.sleep(10) }
+        assertTrue("Callback did not arrive", check())
+    }
+
+    @Test fun wrongCodePublishesFailureAndFreshRetryAcceptsNewCode() {
+        val codes = mutableListOf<String>()
+        service.pair = { _, _, code ->
+            codes += code
+            if (codes.size == 1) throw AdbInvalidPairingCodeException()
+        }
+        start()
+        reply("111111")
+        assertEquals(context.getString(R.string.notification_adb_pairing_failed_title), title())
+        assertEquals(context.getString(R.string.paring_code_is_wrong), notification.extras.getString(Notification.EXTRA_TEXT))
+        assertTrue(shadowOf(notification.actions.single().actionIntent).isForegroundService)
+        start()
+        assertEquals(context.getString(R.string.notification_adb_pairing_searching_for_service_title), title())
+        reply("222222")
+        assertEquals(context.getString(R.string.notification_adb_pairing_succeed_title), title())
+        assertEquals(listOf("111111", "222222"), codes)
+    }
+
+    @Test fun lostEndpointCancelsOldInputAndNewDiscoveryCreatesFreshReply() {
+        start()
+        val listener = nsd.getDiscoveryListeners(AdbMdns.TLS_PAIRING)!!.single()
+        listener.onDiscoveryStarted(AdbMdns.TLS_PAIRING)
+        ServerSocket(0, 1, InetAddress.getLoopbackAddress()).use { socket ->
+            val info = NsdServiceInfo().apply {
+                serviceName = "adb-test"; serviceType = AdbMdns.TLS_PAIRING; host = InetAddress.getLoopbackAddress(); port = socket.localPort
+            }
+            listener.onServiceFound(info); idle()
+            nsd.getResolveListeners(info)!!.last().onServiceResolved(info); idle()
+            await { notification.actions.first().remoteInputs != null }
+            val oldReply = notification.actions.first().actionIntent
+            assertNotNull(notification.actions.first().remoteInputs)
+            listener.onServiceLost(info); idle()
+            assertTrue(shadowOf(oldReply).isCanceled)
+            assertTrue(notification.actions.all { it.remoteInputs == null })
+            listener.onServiceFound(info); idle()
+            nsd.getResolveListeners(info)!!.last().onServiceResolved(info); idle()
+            await { notification.actions.first().remoteInputs != null }
+            assertFalse(shadowOf(notification.actions.first().actionIntent).isCanceled)
+        }
+    }
+
+    @Test fun restartPreventsAnOldAttemptFromReplacingFreshSearch() {
+        val result = CompletableDeferred<Unit>()
+        service.pair = { _, _, _ -> result.await() }
+        start(); reply("123456")
+        assertEquals(context.getString(R.string.notification_adb_pairing_working_title), title())
+        start()
+        result.complete(Unit); idle()
+        assertEquals(context.getString(R.string.notification_adb_pairing_searching_for_service_title), title())
+        assertFalse(shadowOf(service).isStoppedBySelf)
+    }
+
+    @Test fun timeoutAndKeyErrorsRemainRetryable() {
+        start()
+        service.onTimeout(1); idle()
+        assertEquals(context.getString(R.string.notification_adb_pairing_failed_title), title())
+        assertEquals(context.getString(R.string.notification_adb_pairing_retry), notification.actions.single().title)
+        start()
+        service.pair = { _, _, _ -> throw AdbKeyException(IllegalStateException("key unavailable")) }
+        reply("123456")
+        assertEquals(context.getString(R.string.adb_error_key_store), notification.extras.getString(Notification.EXTRA_TEXT))
+    }
+}

--- a/manager/src/test/java/moe/shizuku/manager/adb/TvPairingTest.kt
+++ b/manager/src/test/java/moe/shizuku/manager/adb/TvPairingTest.kt
@@ -1,0 +1,96 @@
+package moe.shizuku.manager.adb
+
+import android.os.Looper
+import android.view.accessibility.AccessibilityEvent
+import android.view.accessibility.AccessibilityNodeInfo
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import moe.shizuku.manager.R
+import moe.shizuku.manager.ShizukuSettings
+import org.junit.After
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.android.controller.ServiceController
+import java.time.Duration
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+class TvPairingTest {
+    private val dispatcher = StandardTestDispatcher()
+    private lateinit var controller: ServiceController<AdbPairingAccessibilityService>
+    private val service get() = controller.get()
+    private val store get() = TvPairingResultStore(ShizukuSettings.getPreferences())
+    private fun idle() { shadowOf(Looper.getMainLooper()).idle(); dispatcher.scheduler.runCurrent() }
+    private fun tree(vararg texts: String) = AccessibilityNodeInfo.obtain().apply {
+        texts.forEach { value -> shadowOf(this).addChild(AccessibilityNodeInfo.obtain().apply { text = value }) }
+    }
+    private fun credentials() {
+        shadowOf(service).setRootInActiveWindow(tree("192.168.1.20:37123", "123456"))
+        service.onAccessibilityEvent(AccessibilityEvent.obtain(AccessibilityEvent.TYPE_WINDOW_CONTENT_CHANGED))
+        idle()
+    }
+
+    @Before fun setup() {
+        Dispatchers.setMain(dispatcher)
+        controller = Robolectric.buildService(AdbPairingAccessibilityService::class.java).create()
+        store.clear()
+    }
+    @After fun cleanup() { controller.destroy(); store.clear(); Dispatchers.resetMain() }
+
+    @Test fun timeoutPersistsRecoveryInstructionsUntilAcknowledged() {
+        service.startPairing()
+        shadowOf(Looper.getMainLooper()).idleFor(Duration.ofSeconds(60))
+        val result = store.read()!!
+        assertFalse(result.success)
+        assertEquals(service.getString(R.string.porter_pairing_search_timeout), result.message)
+        assertEquals(result, TvPairingResultStore(ShizukuSettings.getPreferences()).read())
+        assertNotNull(shadowOf(service).nextStartedActivity)
+        store.clear()
+        assertNull(store.read())
+    }
+
+    @Test fun detectingCredentialsCancelsSearchTimeoutAndPreservesSuccess() {
+        val result = CompletableDeferred<Unit>()
+        var received: PairingCredentials? = null
+        service.pair = { host, port, code -> received = PairingCredentials(host, port, code); result.await() }
+        service.startPairing()
+        credentials()
+        assertEquals(PairingCredentials("192.168.1.20", 37123, "123456"), received)
+        shadowOf(Looper.getMainLooper()).idleFor(Duration.ofSeconds(65))
+        assertNull(store.read())
+        result.complete(Unit); idle()
+        assertTrue(store.read()!!.success)
+        shadowOf(Looper.getMainLooper()).idleFor(Duration.ofSeconds(65))
+        assertTrue(store.read()!!.success)
+    }
+
+    @Test fun keyFailureIsReportedAndNextSessionAcceptsFreshCredentials() {
+        service.pair = { _, _, _ -> throw AdbKeyException(IllegalStateException("unavailable")) }
+        service.startPairing(); credentials()
+        assertFalse(store.read()!!.success)
+        assertEquals(service.getString(R.string.adb_error_key_store), store.read()!!.message)
+        service.onUnbind(null)
+        service.startPairing()
+        assertNull(store.read())
+        service.pair = { _, _, _ -> }
+        credentials()
+        assertTrue(store.read()!!.success)
+    }
+
+    @Test fun partialOrInvalidSnapshotsCannotPairWithOldCredentials() {
+        assertNull(readPairingCredentials(tree("123456")))
+        assertNull(readPairingCredentials(tree("192.168.1.20:37123")))
+        assertNull(readPairingCredentials(tree("192.168.1.20:99999", "123456")))
+        assertEquals(PairingCredentials("192.168.1.20", 37123, "123456"),
+            readPairingCredentials(tree("192.168.1.20:37123", "123456")))
+    }
+}

--- a/manager/src/test/java/moe/shizuku/manager/home/TvPairingResultContentTest.kt
+++ b/manager/src/test/java/moe/shizuku/manager/home/TvPairingResultContentTest.kt
@@ -1,0 +1,35 @@
+package moe.shizuku.manager.home
+
+import android.content.Context
+import androidx.compose.ui.test.*
+import androidx.test.core.app.ApplicationProvider
+import moe.shizuku.manager.ComposeTest
+import moe.shizuku.manager.R
+import moe.shizuku.manager.ui.PorterTheme
+import moe.shizuku.manager.ui.DialogSurface
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class TvPairingResultContentTest : ComposeTest() {
+    private val context = ApplicationProvider.getApplicationContext<Context>()
+    @Test fun failureShowsLastingReasonAndRetryAction() {
+        var retries = 0
+        composeTestRule.setContent {
+            PorterTheme { DialogSurface { TvPairingResultContent(false, "Pairing expired", { retries++ }, {}) } }
+        }
+        composeTestRule.onNodeWithText("Pairing expired").assertIsDisplayed()
+        composeTestRule.onNodeWithText(context.getString(R.string.notification_adb_pairing_retry)).performClick()
+        assertEquals(1, retries)
+    }
+    @Test fun successExplainsStartingIsSeparateAndOffersStart() {
+        var starts = 0
+        composeTestRule.setContent {
+            PorterTheme { DialogSurface {
+                TvPairingResultContent(true, context.getString(R.string.notification_adb_pairing_succeed_text), { starts++ }, {})
+            } }
+        }
+        composeTestRule.onNodeWithText(context.getString(R.string.notification_adb_pairing_succeed_text)).assertIsDisplayed()
+        composeTestRule.onNodeWithText(context.getString(R.string.home_root_button_start)).performClick()
+        assertEquals(1, starts)
+    }
+}


### PR DESCRIPTION
## What changed

Phone pairing can recover from rejected codes and stale notifications without clearing app data. Android TV shows a lasting pairing result with Retry or Start, and new Android pairings use the Porter label. English and German setup guidance covers recovery and TV installation warnings.

## Technical Context

- Restarting pairing now replaces discovery and notification reply actions, cancels the previous attempt, and prevents stale results or process restarts from replaying a single-use code. Socket timeouts bound stalled attempts.
- TV results are saved and displayed after Porter resumes. The one-minute code-search timer stops when the pairing attempt begins.
- The ADB key comment changes to Porter while saved keys and public protocol identifiers remain intact. Existing Android entries can keep their old label until paired again.
- Play Protect controls belong to Android's installer. The guide describes mouse navigation and installation through an already-authorized ADB connection, without promising a bypass. New app strings use English fallback outside German.
- Isolated emulators covered phone wrong-code retry through service start and TV timeout with remote-operated retry; physical-TV pairing success and the reported Play Protect dialog remain unverified.
