### PR TITLE
Hide compatibility app from the launcher

### DIFF
--- a/compat/src/main/AndroidManifest.xml
+++ b/compat/src/main/AndroidManifest.xml
@@ -14,10 +14,6 @@
         <activity android:name=".OpenPorterActivity" android:exported="true"
             android:theme="@android:style/Theme.Material.Light.NoActionBar">
             <intent-filter>
-                <action android:name="android.intent.action.MAIN" />
-                <category android:name="android.intent.category.LAUNCHER" />
-            </intent-filter>
-            <intent-filter>
                 <action android:name="moe.shizuku.manager.intent.action.REQUEST_PERMISSION" />
                 <action android:name="moe.shizuku.privileged.api.intent.action.REQUEST_PERMISSION" />
                 <category android:name="android.intent.category.DEFAULT" />

--- a/manager/src/main/java/moe/shizuku/manager/compatibility/CompatibilityActivity.kt
+++ b/manager/src/main/java/moe/shizuku/manager/compatibility/CompatibilityActivity.kt
@@ -122,7 +122,13 @@ class CompatibilityActivity : ComposeActivity() {
                     CompatibilityRepository.Status.INVALID -> R.string.compat_status_invalid
                 }), if (state.status == CompatibilityRepository.Status.INSTALLED) R.drawable.ic_baseline_link_24 else R.drawable.ic_outline_info_24) {
                     if (state.isCompanion) {
-                        OutlinedCard(Modifier.fillMaxWidth()) {
+                        OutlinedCard(
+                            onClick = {
+                                startActivity(Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS,
+                                    Uri.parse("package:${CompatibilityRepository.PACKAGE}")))
+                            },
+                            modifier = Modifier.fillMaxWidth()
+                        ) {
                             Column(Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(4.dp)) {
                                 Text(state.installedLabel, style = MaterialTheme.typography.titleSmall)
                                 Text(android.text.BidiFormatter.getInstance().unicodeWrap(CompatibilityRepository.PACKAGE, android.text.TextDirectionHeuristics.LTR), style = MaterialTheme.typography.bodySmall)


### PR DESCRIPTION
## What changed

Hide the compatibility app from the launcher. Tapping the installed companion's inline card on Porter's Compatibility screen opens its Android App info settings.

## Technical Context

Keep the companion activity and its legacy permission-request intent filters; only remove its launcher entry.
