### PR TITLE
Show TV pairing progress and confirm accessibility cleanup

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -46,7 +46,7 @@ If you selected **In-app dialog** under **Settings**, **Startup**, **Pairing met
 
 On a TV with wireless debugging, choose **Pairing** in Porter and follow the instructions to enable its pairing accessibility service. Within one minute, open **Developer options**, **Wireless debugging**, then **Pair device with pairing code**. Keep that dialog open while Porter reads the code and completes pairing.
 
-Porter shows the result and turns off its pairing accessibility service. Choose **Start** after success, or **Retry** after a failure or timeout. If Porter does not open automatically, open it to see the result. For installation controls that cannot be selected with a remote, see [TV installation warnings](/troubleshooting#a-tv-installation-warning-cannot-be-selected-with-the-remote).
+Porter displays a progress panel over the pairing-code screen. Leave that screen open until the pairing result appears. Porter then opens its result screen and turns off its pairing accessibility service. The result screen confirms when the service is off, separately from whether pairing worked. Choose **Start** after success, or **Retry** after a failure or timeout. If Porter does not open automatically, open it to see the result. For installation controls that cannot be selected with a remote, see [TV installation warnings](/troubleshooting#a-tv-installation-warning-cannot-be-selected-with-the-remote).
 
 ## With a computer
 

--- a/manager/src/main/java/moe/shizuku/manager/adb/AdbPairingAccessibilityService.kt
+++ b/manager/src/main/java/moe/shizuku/manager/adb/AdbPairingAccessibilityService.kt
@@ -26,15 +26,28 @@ class AdbPairingAccessibilityService : AccessibilityService() {
     private var scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
     private var pairing = false
     private var finished = false
+    private var overlay: TvPairingOverlay? = null
+    private val returnToPorter = Runnable {
+        dismissOverlay()
+        openPorter()
+        disableSelf()
+    }
+    private val visibilityPoll = object : Runnable {
+        override fun run() {
+            val panel = overlay ?: return
+            rootInActiveWindow?.packageName?.let { panel.setVisible(it == TV_SETTINGS_PACKAGE) }
+            handler.postDelayed(this, 1_000)
+        }
+    }
     internal var pair: suspend (String, Int, String) -> Unit = ::pairAdb
     private val timeout = Runnable {
-        finishPairing(false, getString(R.string.porter_pairing_search_timeout))
+        finishPairing(false, tvPairingUiContext().getString(R.string.porter_pairing_search_timeout))
     }
 
     override fun onServiceConnected() {
         super.onServiceConnected()
         if (!(EnvironmentUtils.isTelevision() && EnvironmentUtils.isTlsSupported())) {
-            Toast.makeText(this, R.string.toast_accessibility_tv_only, Toast.LENGTH_SHORT).show()
+            Toast.makeText(tvPairingUiContext(), R.string.toast_accessibility_tv_only, Toast.LENGTH_SHORT).show()
             disableSelf()
             return
         }
@@ -42,6 +55,8 @@ class AdbPairingAccessibilityService : AccessibilityService() {
     }
 
     internal fun startPairing() {
+        handler.removeCallbacks(returnToPorter)
+        dismissOverlay()
         scope.cancel()
         scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
         pairing = false
@@ -66,21 +81,35 @@ class AdbPairingAccessibilityService : AccessibilityService() {
     override fun onAccessibilityEvent(event: AccessibilityEvent?) {
         if (event == null || pairing || finished) return
         val root = rootInActiveWindow ?: event.source ?: return
-        val credentials = readPairingCredentials(root) ?: return
+        if (root.packageName != TV_SETTINGS_PACKAGE) return
+        val credentials = readPairingCredentials(root)
+        if (credentials != null || isPairingCodeWindow(root)) showOverlay()
+        if (credentials == null) return
         pairing = true
         handler.removeCallbacks(timeout)
         scope.launch {
             try {
                 pair(credentials.host, credentials.port, credentials.code)
                 coroutineContext.ensureActive()
-                finishPairing(true, getString(R.string.notification_adb_pairing_succeed_text))
+                finishPairing(true, tvPairingUiContext().getString(R.string.notification_adb_pairing_succeed_text))
             } catch (e: CancellationException) {
                 throw e
             } catch (e: Exception) {
                 coroutineContext.ensureActive()
                 Log.w("AdbPairingAccessibility", "Pairing failed", e)
-                finishPairing(false, pairingFailureMessage(e))
+                finishPairing(false, tvPairingUiContext().pairingFailureMessage(e))
             }
+        }
+    }
+
+    private fun showOverlay() {
+        if (overlay != null) return
+        try {
+            overlay = TvPairingOverlay(this).also { it.show() }
+            handler.postDelayed(visibilityPoll, 1_000)
+        } catch (e: Exception) {
+            Log.w("AdbPairingAccessibility", "Cannot show pairing progress", e)
+            dismissOverlay()
         }
     }
 
@@ -89,8 +118,18 @@ class AdbPairingAccessibilityService : AccessibilityService() {
         finished = true
         handler.removeCallbacks(timeout)
         TvPairingResultStore(ShizukuSettings.getPreferences()).save(TvPairingResult(success, message))
-        openPorter()
-        disableSelf()
+        if (overlay?.isVisible == true) {
+            overlay?.showResult(success)
+            handler.postDelayed(returnToPorter, 2_500)
+        } else {
+            returnToPorter.run()
+        }
+    }
+
+    private fun dismissOverlay() {
+        handler.removeCallbacks(visibilityPoll)
+        overlay?.dismiss()
+        overlay = null
     }
 
     override fun onInterrupt() {}
@@ -98,17 +137,29 @@ class AdbPairingAccessibilityService : AccessibilityService() {
     override fun onUnbind(intent: Intent?): Boolean {
         handler.removeCallbacksAndMessages(null)
         scope.cancel()
+        dismissOverlay()
         return super.onUnbind(intent)
     }
 
     override fun onDestroy() {
         handler.removeCallbacksAndMessages(null)
         scope.cancel()
+        dismissOverlay()
         super.onDestroy()
     }
 }
 
 internal data class PairingCredentials(val host: String, val port: Int, val code: String)
+
+internal const val TV_SETTINGS_PACKAGE = "com.android.tv.settings"
+
+internal fun isPairingCodeWindow(root: AccessibilityNodeInfo): Boolean {
+    if (root.viewIdResourceName == "$TV_SETTINGS_PACKAGE:id/pairing_code") return true
+    for (index in 0 until root.childCount) {
+        if (root.getChild(index)?.let(::isPairingCodeWindow) == true) return true
+    }
+    return false
+}
 
 internal fun readPairingCredentials(root: AccessibilityNodeInfo): PairingCredentials? {
     var endpoint: Pair<String, Int>? = null

--- a/manager/src/main/java/moe/shizuku/manager/adb/TvPairingOverlay.kt
+++ b/manager/src/main/java/moe/shizuku/manager/adb/TvPairingOverlay.kt
@@ -1,0 +1,105 @@
+package moe.shizuku.manager.adb
+
+import android.accessibilityservice.AccessibilityService
+import android.app.LocaleManager
+import android.content.Context
+import android.content.res.Configuration
+import android.content.res.Resources
+import android.graphics.Color
+import android.graphics.PixelFormat
+import android.graphics.Typeface
+import android.graphics.drawable.GradientDrawable
+import android.os.Build
+import android.util.Log
+import android.view.Gravity
+import android.view.View
+import android.view.WindowManager
+import android.widget.LinearLayout
+import android.widget.TextView
+import moe.shizuku.manager.R
+
+internal class TvPairingOverlay(private val service: AccessibilityService) {
+    private val context = service.tvPairingUiContext()
+    private val windows = service.getSystemService(WindowManager::class.java)
+    private var panel: LinearLayout? = null
+    private var result: TextView? = null
+    private var completion: TextView? = null
+    val isVisible: Boolean get() = panel?.visibility == View.VISIBLE
+    private fun dp(value: Int) = (value * service.resources.displayMetrics.density).toInt()
+
+    fun show() {
+        if (panel != null) return
+        val view = LinearLayout(context).apply {
+            orientation = LinearLayout.VERTICAL
+            setPadding(dp(24), dp(20), dp(24), dp(20))
+            background = GradientDrawable().apply {
+                setColor(Color.rgb(30, 34, 40))
+                cornerRadius = dp(20).toFloat()
+            }
+            accessibilityLiveRegion = View.ACCESSIBILITY_LIVE_REGION_POLITE
+        }
+        fun line(text: String, title: Boolean = false) = TextView(context).apply {
+            this.text = text
+            textSize = if (title) 22f else 18f
+            setTextColor(Color.WHITE)
+            if (title) setTypeface(typeface, Typeface.BOLD)
+            setPadding(0, 0, 0, dp(8))
+            view.addView(this)
+        }
+        line(context.getString(R.string.porter_tv_pairing_progress_title), title = true)
+        line(context.getString(R.string.porter_tv_pairing_wait))
+        result = line("").apply { visibility = View.GONE }
+        completion = line("").apply { visibility = View.GONE }
+        val params = WindowManager.LayoutParams(
+            dp(560).coerceAtMost(service.resources.displayMetrics.widthPixels - dp(64)),
+            WindowManager.LayoutParams.WRAP_CONTENT,
+            WindowManager.LayoutParams.TYPE_ACCESSIBILITY_OVERLAY,
+            WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE or WindowManager.LayoutParams.FLAG_NOT_TOUCHABLE,
+            PixelFormat.TRANSLUCENT,
+        ).apply {
+            // Placement follows TV Settings; Porter's selected language can have a different direction.
+            gravity = Gravity.BOTTOM or Gravity.getAbsoluteGravity(
+                Gravity.START, Resources.getSystem().configuration.layoutDirection,
+            )
+            x = dp(24)
+            y = dp(24)
+            setTitle("Porter pairing progress")
+        }
+        windows.addView(view, params)
+        panel = view
+    }
+
+    fun showResult(success: Boolean) {
+        result?.apply {
+            setText(if (success) R.string.notification_adb_pairing_succeed_title else R.string.notification_adb_pairing_failed_title)
+            visibility = View.VISIBLE
+        }
+        completion?.apply {
+            setText(R.string.porter_tv_pairing_return)
+            visibility = View.VISIBLE
+        }
+    }
+
+    fun dismiss() {
+        val view = panel ?: return
+        panel = null
+        result = null
+        completion = null
+        try {
+            windows.removeViewImmediate(view)
+        } catch (e: IllegalArgumentException) {
+            Log.w("TvPairingOverlay", "Overlay already removed", e)
+        }
+    }
+
+    fun setVisible(visible: Boolean) {
+        panel?.visibility = if (visible) View.VISIBLE else View.GONE
+    }
+}
+
+internal fun Context.tvPairingUiContext(): Context {
+    if (Build.VERSION.SDK_INT < 33) return this
+    val locales = getSystemService(LocaleManager::class.java).applicationLocales
+    if (locales.isEmpty) return this
+    return createConfigurationContext(Configuration(resources.configuration).apply { setLocales(locales) })
+}

--- a/manager/src/main/java/moe/shizuku/manager/home/AccessibilityDialogHelper.kt
+++ b/manager/src/main/java/moe/shizuku/manager/home/AccessibilityDialogHelper.kt
@@ -66,7 +66,7 @@ private fun Context.getEnabledAccessibilityServices(): List<String>? {
     return enabledServices?.split(":")
 }
 
-private fun Context.isAccessibilityEnabled(): Boolean {
+internal fun Context.isAccessibilityEnabled(): Boolean {
     val accessibilityServiceName = "$packageName/${AdbPairingAccessibilityService::class.java.canonicalName}"
     return getEnabledAccessibilityServices()?.any { it.equals(accessibilityServiceName) } ?: false
 }

--- a/manager/src/main/java/moe/shizuku/manager/home/TvPairingResultDialogFragment.kt
+++ b/manager/src/main/java/moe/shizuku/manager/home/TvPairingResultDialogFragment.kt
@@ -1,18 +1,30 @@
 package moe.shizuku.manager.home
 
+import android.content.Context
 import android.os.Bundle
+import android.database.ContentObserver
+import android.os.Handler
+import android.os.Looper
+import android.provider.Settings
 import androidx.compose.material3.*
-import androidx.compose.runtime.Composable
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.res.stringResource
 import androidx.lifecycle.lifecycleScope
+import kotlinx.coroutines.delay
 import moe.shizuku.manager.R
 import moe.shizuku.manager.ShizukuSettings
 import moe.shizuku.manager.adb.TvPairingResult
 import moe.shizuku.manager.adb.TvPairingResultStore
 import moe.shizuku.manager.ui.ComposeDialogFragment
+import moe.shizuku.manager.utils.SettingsPage
 
 class TvPairingResultDialogFragment : ComposeDialogFragment() {
     @Composable override fun Content() {
+        val context = requireContext()
+        val (serviceEnabled, cleanupDelayed) = rememberTvPairingCleanupState(context)
         val success = requireArguments().getBoolean("success")
         TvPairingResultContent(success, requireArguments().getString("message").orEmpty(),
             onAction = {
@@ -21,9 +33,10 @@ class TvPairingResultDialogFragment : ComposeDialogFragment() {
                 if (success) WirelessStart.start(requireActivity(), requireActivity().lifecycleScope)
                 else WirelessStart.pair(requireContext())
             }, onClose = {
-                TvPairingResultStore(ShizukuSettings.getPreferences()).clear()
+                if (!context.isAccessibilityEnabled()) TvPairingResultStore(ShizukuSettings.getPreferences()).clear()
                 dismissAllowingStateLoss()
-            })
+            }, serviceEnabled = serviceEnabled, cleanupDelayed = cleanupDelayed,
+            onAccessibilitySettings = { SettingsPage.Accessibility.launch(context) })
     }
 
     companion object {
@@ -36,12 +49,59 @@ class TvPairingResultDialogFragment : ComposeDialogFragment() {
     }
 }
 
+internal data class TvPairingCleanupState(val serviceEnabled: Boolean, val cleanupDelayed: Boolean)
+
 @Composable
-internal fun TvPairingResultContent(success: Boolean, message: String, onAction: () -> Unit, onClose: () -> Unit) {
+internal fun rememberTvPairingCleanupState(context: Context): TvPairingCleanupState {
+    var serviceEnabled by remember { mutableStateOf(context.isAccessibilityEnabled()) }
+    var cleanupDelayed by remember { mutableStateOf(false) }
+    DisposableEffect(context) {
+        val observer = object : ContentObserver(Handler(Looper.getMainLooper())) {
+            override fun onChange(selfChange: Boolean) {
+                serviceEnabled = context.isAccessibilityEnabled()
+            }
+        }
+        context.contentResolver.registerContentObserver(
+            Settings.Secure.getUriFor(Settings.Secure.ENABLED_ACCESSIBILITY_SERVICES), false, observer)
+        serviceEnabled = context.isAccessibilityEnabled()
+        onDispose { context.contentResolver.unregisterContentObserver(observer) }
+    }
+    LaunchedEffect(serviceEnabled) {
+        cleanupDelayed = false
+        if (serviceEnabled) {
+            delay(5_000)
+            cleanupDelayed = true
+        }
+    }
+    return TvPairingCleanupState(serviceEnabled, cleanupDelayed)
+}
+
+@Composable
+internal fun TvPairingResultContent(
+    success: Boolean,
+    message: String,
+    onAction: () -> Unit,
+    onClose: () -> Unit,
+    serviceEnabled: Boolean = false,
+    cleanupDelayed: Boolean = false,
+    onAccessibilitySettings: () -> Unit = {},
+) {
     Text(stringResource(if (success) R.string.notification_adb_pairing_succeed_title
         else R.string.notification_adb_pairing_failed_title), style = MaterialTheme.typography.headlineSmall)
     Text(message)
-    Button(onClick = onAction) {
+    Text(stringResource(when {
+        !serviceEnabled -> R.string.porter_tv_pairing_complete
+        cleanupDelayed -> R.string.porter_tv_pairing_cleanup_delayed
+        else -> R.string.porter_tv_pairing_disabling
+    }))
+    if (serviceEnabled && cleanupDelayed) {
+        TextButton(onClick = onAccessibilitySettings) { Text(stringResource(R.string.porter_tv_pairing_open_accessibility)) }
+    }
+    val actionFocus = remember { FocusRequester() }
+    LaunchedEffect(serviceEnabled) {
+        if (!serviceEnabled) actionFocus.requestFocus()
+    }
+    Button(onClick = onAction, enabled = !serviceEnabled, modifier = Modifier.focusRequester(actionFocus)) {
         Text(stringResource(if (success) R.string.home_root_button_start else R.string.notification_adb_pairing_retry))
     }
     TextButton(onClick = onClose) { Text(stringResource(android.R.string.ok)) }

--- a/manager/src/main/res/values-de/strings.xml
+++ b/manager/src/main/res/values-de/strings.xml
@@ -212,4 +212,11 @@
     <string name="porter_pairing_attempt_timeout">Zeitüberschreitung bei der Kopplungsverbindung. Öffne in den Einstellungen für drahtloses Debugging einen neuen Kopplungscode-Dialog und versuche es erneut.</string>
     <string name="porter_pairing_failed_retry">Kopplung fehlgeschlagen. Öffne in den Einstellungen für drahtloses Debugging einen neuen Kopplungscode-Dialog und versuche es erneut.</string>
     <string name="porter_pairing_notification_timeout">Die Kopplung wurde beendet, weil die Benachrichtigung abgelaufen ist. Wähle „Erneut versuchen“ und öffne in den Einstellungen für drahtloses Debugging einen neuen Kopplungscode-Dialog.</string>
+    <string name="porter_tv_pairing_progress_title">Porter-Kopplung</string>
+    <string name="porter_tv_pairing_wait">Bitte lasse das Fenster mit dem Kopplungscode geöffnet und warte.</string>
+    <string name="porter_tv_pairing_return">Porter wird geöffnet, um den Bedienungshilfen-Dienst für die Kopplung zu deaktivieren…</string>
+    <string name="porter_tv_pairing_disabling">Der Bedienungshilfen-Dienst für die Kopplung wird deaktiviert…</string>
+    <string name="porter_tv_pairing_complete">Der Bedienungshilfen-Dienst für die Kopplung ist deaktiviert. Alle Kopplungsschritte sind abgeschlossen. Du kannst dieses Fenster schließen.</string>
+    <string name="porter_tv_pairing_cleanup_delayed">Der Bedienungshilfen-Dienst für die Kopplung ist noch aktiviert. Deaktiviere ihn in den Einstellungen für Bedienungshilfen.</string>
+    <string name="porter_tv_pairing_open_accessibility">Einstellungen für Bedienungshilfen öffnen</string>
 </resources>

--- a/manager/src/main/res/values/strings.xml
+++ b/manager/src/main/res/values/strings.xml
@@ -215,4 +215,11 @@
     <string name="porter_pairing_attempt_timeout">The pairing connection timed out. Open a new pairing-code dialog in Wireless debugging and try again.</string>
     <string name="porter_pairing_failed_retry">Pairing failed. Open a new pairing-code dialog in Wireless debugging and try again.</string>
     <string name="porter_pairing_notification_timeout">Pairing has stopped because the notification timed out. Choose Retry, then open a new pairing-code dialog in Wireless debugging.</string>
+    <string name="porter_tv_pairing_progress_title">Porter pairing</string>
+    <string name="porter_tv_pairing_wait">Please leave the pairing-code window open and wait.</string>
+    <string name="porter_tv_pairing_return">Returning to Porter to turn off the pairing accessibility service…</string>
+    <string name="porter_tv_pairing_disabling">Turning off the pairing accessibility service…</string>
+    <string name="porter_tv_pairing_complete">The pairing accessibility service is off. All pairing steps are complete. You can close this window.</string>
+    <string name="porter_tv_pairing_cleanup_delayed">The pairing accessibility service is still enabled. Turn it off in Accessibility settings.</string>
+    <string name="porter_tv_pairing_open_accessibility">Open Accessibility settings</string>
 </resources>

--- a/manager/src/main/res/xml/accessibility_service_config.xml
+++ b/manager/src/main/res/xml/accessibility_service_config.xml
@@ -1,8 +1,8 @@
 <accessibility-service xmlns:android="http://schemas.android.com/apk/res/android"
     android:description="@string/accessibility_service_description"
     android:packageNames="com.android.tv.settings"
-    android:accessibilityFlags="flagDefault|flagRetrieveInteractiveWindows"
-    android:accessibilityEventTypes="typeWindowContentChanged"
+    android:accessibilityFlags="flagDefault|flagRetrieveInteractiveWindows|flagReportViewIds"
+    android:accessibilityEventTypes="typeWindowContentChanged|typeWindowStateChanged"
     android:accessibilityFeedbackType="feedbackGeneric"
     android:canRetrieveWindowContent="true"
 />

--- a/manager/src/test/java/moe/shizuku/manager/adb/TvPairingTest.kt
+++ b/manager/src/test/java/moe/shizuku/manager/adb/TvPairingTest.kt
@@ -1,6 +1,12 @@
 package moe.shizuku.manager.adb
 
 import android.os.Looper
+import android.os.LocaleList
+import android.app.LocaleManager
+import android.widget.LinearLayout
+import android.widget.TextView
+import android.view.View
+import android.view.WindowManager
 import android.view.accessibility.AccessibilityEvent
 import android.view.accessibility.AccessibilityNodeInfo
 import kotlinx.coroutines.CompletableDeferred
@@ -20,6 +26,8 @@ import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.Shadows.shadowOf
 import org.robolectric.android.controller.ServiceController
+import org.robolectric.shadow.api.Shadow
+import org.robolectric.shadows.ShadowWindowManagerImpl
 import java.time.Duration
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -29,8 +37,10 @@ class TvPairingTest {
     private lateinit var controller: ServiceController<AdbPairingAccessibilityService>
     private val service get() = controller.get()
     private val store get() = TvPairingResultStore(ShizukuSettings.getPreferences())
+    private val views get() = Shadow.extract<ShadowWindowManagerImpl>(service.getSystemService(WindowManager::class.java)).views
     private fun idle() { shadowOf(Looper.getMainLooper()).idle(); dispatcher.scheduler.runCurrent() }
     private fun tree(vararg texts: String) = AccessibilityNodeInfo.obtain().apply {
+        packageName = TV_SETTINGS_PACKAGE
         texts.forEach { value -> shadowOf(this).addChild(AccessibilityNodeInfo.obtain().apply { text = value }) }
     }
     private fun credentials() {
@@ -93,4 +103,107 @@ class TvPairingTest {
         assertEquals(PairingCredentials("192.168.1.20", 37123, "123456"),
             readPairingCredentials(tree("192.168.1.20:37123", "123456")))
     }
+
+    @Test fun unbindingDuringPairingCancelsWorkAndDoesNotReopenPorter() {
+        val result = CompletableDeferred<Unit>()
+        service.pair = { _, _, _ -> result.await() }
+        service.startPairing()
+        shadowOf(service).nextStartedActivity
+        credentials()
+        assertEquals(1, views.size)
+        service.onUnbind(null)
+        assertTrue(views.isEmpty())
+        result.complete(Unit)
+        idle()
+        shadowOf(Looper.getMainLooper()).idleFor(Duration.ofSeconds(65))
+        assertNull(store.read())
+        assertNull(shadowOf(service).nextStartedActivity)
+    }
+
+    @Test fun blankPairingCodeWindowShowsProgressBeforeCredentialsAndStillTimesOut() {
+        var attempts = 0
+        service.pair = { _, _, _ -> attempts++ }
+        service.startPairing()
+        val root = tree().apply { viewIdResourceName = "$TV_SETTINGS_PACKAGE:id/pairing_code" }
+        shadowOf(service).setRootInActiveWindow(root)
+        service.onAccessibilityEvent(AccessibilityEvent.obtain(AccessibilityEvent.TYPE_WINDOW_STATE_CHANGED))
+        idle()
+        assertEquals(1, views.size)
+        assertEquals(0, attempts)
+        shadowOf(Looper.getMainLooper()).idleFor(Duration.ofSeconds(60))
+        assertFalse(store.read()!!.success)
+        shadowOf(Looper.getMainLooper()).idleFor(Duration.ofSeconds(3))
+        assertTrue(views.isEmpty())
+    }
+
+    @Test fun resultRemainsVisibleBeforeHandoffAndDuplicateEventsDoNotPairAgain() {
+        var attempts = 0
+        service.pair = { _, _, _ -> attempts++ }
+        service.startPairing()
+        shadowOf(service).nextStartedActivity
+        val root = tree().apply { viewIdResourceName = "$TV_SETTINGS_PACKAGE:id/pairing_code" }
+        shadowOf(service).setRootInActiveWindow(root)
+        service.onAccessibilityEvent(AccessibilityEvent.obtain(AccessibilityEvent.TYPE_WINDOW_STATE_CHANGED))
+        credentials()
+        credentials()
+        assertEquals(1, attempts)
+        assertEquals(1, views.size)
+        val params = views.single().layoutParams as WindowManager.LayoutParams
+        assertEquals(WindowManager.LayoutParams.TYPE_ACCESSIBILITY_OVERLAY, params.type)
+        assertTrue(params.flags and WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE != 0)
+        assertTrue(params.flags and WindowManager.LayoutParams.FLAG_NOT_TOUCHABLE != 0)
+        shadowOf(Looper.getMainLooper()).idleFor(Duration.ofMillis(2400))
+        assertNull(shadowOf(service).nextStartedActivity)
+        assertEquals(1, views.size)
+        shadowOf(Looper.getMainLooper()).idleFor(Duration.ofMillis(200))
+        assertNotNull(shadowOf(service).nextStartedActivity)
+        assertTrue(views.isEmpty())
+    }
+
+    @Test fun unbindingDuringResultRetentionRemovesOverlayAndCancelsHandoff() {
+        service.pair = { _, _, _ -> }
+        service.startPairing()
+        shadowOf(service).nextStartedActivity
+        credentials()
+        assertEquals(1, views.size)
+        service.onUnbind(null)
+        shadowOf(Looper.getMainLooper()).idleFor(Duration.ofSeconds(3))
+        assertTrue(views.isEmpty())
+        assertNull(shadowOf(service).nextStartedActivity)
+        assertTrue(store.read()!!.success)
+    }
+
+    @Test fun leavingSettingsHidesOverlayAndCompletionDoesNotWaitForHiddenPanel() {
+        val result = CompletableDeferred<Unit>()
+        service.pair = { _, _, _ -> result.await() }
+        service.startPairing()
+        shadowOf(service).nextStartedActivity
+        credentials()
+        shadowOf(service).setRootInActiveWindow(tree().apply { packageName = "com.example.launcher" })
+        shadowOf(Looper.getMainLooper()).idleFor(Duration.ofSeconds(1))
+        assertEquals(View.GONE, views.single().visibility)
+        result.complete(Unit); idle()
+        assertTrue(views.isEmpty())
+        assertNotNull(shadowOf(service).nextStartedActivity)
+    }
+
+    @Test fun destroyingWhilePairingRemovesOverlay() {
+        service.pair = { _, _, _ -> CompletableDeferred<Unit>().await() }
+        service.startPairing()
+        credentials()
+        assertEquals(1, views.size)
+        service.onDestroy()
+        assertTrue(views.isEmpty())
+    }
+
+    @Test fun serviceUsesTheSelectedAppLanguageForOverlayAndPersistedResult() {
+        service.getSystemService(LocaleManager::class.java).applicationLocales = LocaleList.forLanguageTags("de")
+        service.pair = { _, _, _ -> }
+        service.startPairing()
+        credentials()
+        val title = (views.single() as LinearLayout).getChildAt(0) as TextView
+        assertEquals("Porter-Kopplung", title.text.toString())
+        assertEquals("Du kannst den Porter-Dienst jetzt starten.", store.read()!!.message)
+    }
+
 }

--- a/manager/src/test/java/moe/shizuku/manager/home/TvPairingResultContentTest.kt
+++ b/manager/src/test/java/moe/shizuku/manager/home/TvPairingResultContentTest.kt
@@ -1,6 +1,12 @@
 package moe.shizuku.manager.home
 
 import android.content.Context
+import android.provider.Settings
+import android.os.Looper
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.SideEffect
+import androidx.compose.ui.input.InputMode
+import androidx.compose.ui.platform.LocalInputModeManager
 import androidx.compose.ui.test.*
 import androidx.test.core.app.ApplicationProvider
 import moe.shizuku.manager.ComposeTest
@@ -9,6 +15,7 @@ import moe.shizuku.manager.ui.PorterTheme
 import moe.shizuku.manager.ui.DialogSurface
 import org.junit.Assert.assertEquals
 import org.junit.Test
+import org.robolectric.Shadows.shadowOf
 
 class TvPairingResultContentTest : ComposeTest() {
     private val context = ApplicationProvider.getApplicationContext<Context>()
@@ -18,8 +25,36 @@ class TvPairingResultContentTest : ComposeTest() {
             PorterTheme { DialogSurface { TvPairingResultContent(false, "Pairing expired", { retries++ }, {}) } }
         }
         composeTestRule.onNodeWithText("Pairing expired").assertIsDisplayed()
+        composeTestRule.onNodeWithText(context.getString(R.string.porter_tv_pairing_complete)).assertIsDisplayed()
         composeTestRule.onNodeWithText(context.getString(R.string.notification_adb_pairing_retry)).performClick()
         assertEquals(1, retries)
+    }
+
+    @Test fun cleanupPendingDoesNotClaimCompletionOrAllowRetry() {
+        composeTestRule.setContent {
+            PorterTheme { DialogSurface {
+                TvPairingResultContent(false, "Pairing expired", {}, {}, serviceEnabled = true)
+            } }
+        }
+        composeTestRule.onNodeWithText("Pairing expired").assertIsDisplayed()
+        composeTestRule.onNodeWithText(context.getString(R.string.porter_tv_pairing_disabling)).assertIsDisplayed()
+        composeTestRule.onNodeWithText(context.getString(R.string.porter_tv_pairing_complete)).assertDoesNotExist()
+        composeTestRule.onNodeWithText(context.getString(R.string.notification_adb_pairing_retry)).assertIsNotEnabled()
+    }
+
+    @Test fun delayedCleanupOffersSettingsWithoutChangingPairingOutcome() {
+        var opened = 0
+        composeTestRule.setContent {
+            PorterTheme { DialogSurface {
+                TvPairingResultContent(true, "Paired", {}, {}, serviceEnabled = true,
+                    cleanupDelayed = true, onAccessibilitySettings = { opened++ })
+            } }
+        }
+        composeTestRule.onNodeWithText("Paired").assertIsDisplayed()
+        composeTestRule.onNodeWithText(context.getString(R.string.porter_tv_pairing_cleanup_delayed)).assertIsDisplayed()
+        composeTestRule.onNodeWithText(context.getString(R.string.porter_tv_pairing_open_accessibility)).performClick()
+        assertEquals(1, opened)
+        composeTestRule.onNodeWithText(context.getString(R.string.home_root_button_start)).assertIsNotEnabled()
     }
     @Test fun successExplainsStartingIsSeparateAndOffersStart() {
         var starts = 0
@@ -31,5 +66,45 @@ class TvPairingResultContentTest : ComposeTest() {
         composeTestRule.onNodeWithText(context.getString(R.string.notification_adb_pairing_succeed_text)).assertIsDisplayed()
         composeTestRule.onNodeWithText(context.getString(R.string.home_root_button_start)).performClick()
         assertEquals(1, starts)
+    }
+
+    @Test fun cleanupObservesServiceDisableAndStopsObservingWhenDisposed() {
+        val resolver = context.contentResolver
+        val uri = Settings.Secure.getUriFor(Settings.Secure.ENABLED_ACCESSIBILITY_SERVICES)
+        val existingObservers = shadowOf(resolver).getContentObservers(uri).toSet()
+        val visible = mutableStateOf(true)
+        Settings.Secure.putString(resolver, Settings.Secure.ENABLED_ACCESSIBILITY_SERVICES,
+            "${context.packageName}/moe.shizuku.manager.adb.AdbPairingAccessibilityService")
+        composeTestRule.mainClock.autoAdvance = false
+        composeTestRule.setContent {
+            val inputMode = LocalInputModeManager.current
+            SideEffect { inputMode.requestInputMode(InputMode.Keyboard) }
+            if (visible.value) {
+                val state = rememberTvPairingCleanupState(context)
+                PorterTheme { DialogSurface {
+                    TvPairingResultContent(false, "Pairing expired", {}, {},
+                        serviceEnabled = state.serviceEnabled, cleanupDelayed = state.cleanupDelayed)
+                } }
+            }
+        }
+        composeTestRule.mainClock.advanceTimeByFrame()
+        composeTestRule.onNodeWithText(context.getString(R.string.porter_tv_pairing_disabling)).assertIsDisplayed()
+        composeTestRule.mainClock.advanceTimeBy(5_100)
+        composeTestRule.onNodeWithText(context.getString(R.string.porter_tv_pairing_cleanup_delayed)).assertIsDisplayed()
+        composeTestRule.runOnIdle {
+            Settings.Secure.putString(resolver, Settings.Secure.ENABLED_ACCESSIBILITY_SERVICES, "")
+            resolver.notifyChange(uri, null)
+            shadowOf(Looper.getMainLooper()).idle()
+        }
+        composeTestRule.mainClock.advanceTimeBy(1_000)
+        composeTestRule.onNodeWithText(context.getString(R.string.porter_tv_pairing_complete)).assertExists()
+        composeTestRule.onNodeWithText(context.getString(R.string.notification_adb_pairing_retry)).assertIsEnabled().assertIsFocused()
+        composeTestRule.runOnIdle { visible.value = false }
+        composeTestRule.mainClock.autoAdvance = true
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithText("Pairing expired").assertDoesNotExist()
+        composeTestRule.runOnIdle {
+            assertEquals(existingObservers, shadowOf(resolver).getContentObservers(uri).toSet())
+        }
     }
 }


### PR DESCRIPTION
## What changed

Show a persistent progress panel over the Android TV pairing-code screen, asking users to leave it open and displaying the pairing result. Porter then confirms that its pairing accessibility service is off, independently of whether pairing succeeded. Includes English and German text.

## Technical Context

- Uses the existing TV-only accessibility service to show a noninteractive overlay, without an additional overlay permission. The panel appears before credentials are complete on the standard TV Settings screen and hides over other apps.
- Holds the result briefly before returning to Porter. Start and Retry wait for confirmed service shutdown; delayed cleanup offers Accessibility settings.
- Resolves the app language in the service context while positioning the panel using the system text direction to keep pairing credentials visible.
- Android 14 TV emulator testing covered real pairing, an induced key-store failure, German text, and service shutdown; a phone emulator confirmed that the TV service immediately disables itself.
