### PR TITLE
fix: confirm the stop dialog in the emulator smoke test

### DIFF
--- a/tools/ci/emulator-smoke.py
+++ b/tools/ci/emulator-smoke.py
@@ -63,16 +63,19 @@ class Smoke:
         (self.output / "last-ui.xml").write_text(xml)
         return ET.fromstring(xml)
 
-    def tap(self, text, package=MANAGER, prefix=False, screenshot=None, scroll=False):
+    def tap(self, text, package=MANAGER, prefix=False, screenshot=None, scroll=False, occurrence=0):
         def locate():
             root = self.ui()
+            found = []
             for node in root.iter("node"):
                 label = node.get("text", "")
                 matches = label.startswith(text) if prefix else label == text
                 if node.get("package") == package and matches and node.get("enabled") == "true":
                     bounds = list(map(int, re.findall(r"\d+", node.get("bounds", ""))))
                     if len(bounds) == 4:
-                        return bounds
+                        found.append(bounds)
+                        if len(found) > occurrence:
+                            return found[occurrence]
             if scroll:
                 container = next((n for n in root.iter("node") if n.get("package") == package
                                   and n.get("scrollable") == "true"), None)
@@ -82,7 +85,8 @@ class Smoke:
                     inset = (bottom - top) // 5
                     self.shell("input", "swipe", x, bottom - inset, x, top + inset, 300)
             return None
-        left, top, right, bottom = self.until(f"button {text!r} in {package}", locate)
+        ordinal = f" #{occurrence}" if occurrence else ""
+        left, top, right, bottom = self.until(f"button {text!r}{ordinal} in {package}", locate)
         if screenshot:
             self.screenshot(screenshot)
         self.shell("input", "tap", (left + right) // 2, (top + bottom) // 2)
@@ -138,7 +142,10 @@ class Smoke:
     def stop_porter(self):
         self.shell("am", "start", "-W", "-f", "0x04000000", "-n", MANAGER + "/moe.shizuku.manager.MainActivity")
         self.tap("Porter is running", prefix=True)
-        self.tap("Stop Porter", screenshot="running-service-dialog")
+        self.tap("Stop Porter")
+        # The dialog repeats "Stop Porter" as its title, so the second match is the confirm button
+        # and waiting for it also waits for the dialog to replace the single-match screen.
+        self.tap("Stop Porter", occurrence=1, screenshot="running-service-dialog")
         self.until("Porter stopped", lambda: not self.pid("porter_server"))
 
     def case(self, name, action):

--- a/tools/ci/test_emulator_smoke.py
+++ b/tools/ci/test_emulator_smoke.py
@@ -44,3 +44,46 @@ class ScrollToActionTest(unittest.TestCase):
         with self.assertRaisesRegex(AssertionError, "Timed out"):
             self.runner.tap("Install automatically")
         self.runner.shell.assert_not_called()
+
+
+class StopPorterConfirmationTest(unittest.TestCase):
+    def setUp(self):
+        self.runner = smoke.Smoke.__new__(smoke.Smoke)
+        self.runner.shell = Mock()
+        self.runner.screenshot = Mock()
+        self.home = ET.fromstring('''<hierarchy><node package="eu.darken.porter">
+            <node text="Porter is running" package="eu.darken.porter" enabled="true"
+            bounds="[200,326][524,389]" /></node></hierarchy>''')
+        self.service = ET.fromstring('''<hierarchy><node package="eu.darken.porter">
+            <node text="Stop Porter" package="eu.darken.porter" enabled="true"
+            bounds="[158,595][347,648]" /></node></hierarchy>''')
+        # A dialog covers the screen behind it, so only its own window is dumped.
+        self.dialog = ET.fromstring('''<hierarchy><node package="eu.darken.porter">
+            <node text="Stop Porter" package="eu.darken.porter" enabled="true"
+            bounds="[183,691][501,775]" />
+            <node text="Cancel" package="eu.darken.porter" enabled="true"
+            bounds="[477,1076][591,1129]" />
+            <node text="Stop Porter" package="eu.darken.porter" enabled="true"
+            bounds="[676,1076][865,1129]" /></node></hierarchy>''')
+
+    @patch.object(smoke.time, "sleep")
+    def test_confirms_the_dialog_before_waiting_for_the_server_to_exit(self, sleep):
+        self.runner.ui = Mock(side_effect=[self.home, self.service, self.service, self.dialog])
+        self.runner.pid = Mock(side_effect=["5271", ""])
+        self.runner.stop_porter()
+        self.assertEqual(self.runner.shell.call_args_list, [
+            call("am", "start", "-W", "-f", "0x04000000",
+                 "-n", "eu.darken.porter/moe.shizuku.manager.MainActivity"),
+            call("input", "tap", 362, 357),
+            call("input", "tap", 252, 621),
+            call("input", "tap", 770, 1102),
+        ])
+        self.runner.screenshot.assert_called_once_with("running-service-dialog")
+
+    @patch.object(smoke.time, "sleep")
+    @patch.object(smoke.time, "monotonic", side_effect=[0, 0, 31])
+    def test_a_single_match_never_satisfies_the_confirm_button(self, monotonic, sleep):
+        self.runner.ui = Mock(return_value=self.service)
+        with self.assertRaisesRegex(AssertionError, "Timed out"):
+            self.runner.tap("Stop Porter", occurrence=1)
+        self.runner.shell.assert_not_called()


### PR DESCRIPTION
## What changed

No user-facing behavior change. The emulator integration tests stop failing.

Stopping Porter now goes through a dedicated service screen with a confirmation dialog. The smoke test still performed the two taps the old inline dialog needed, so it tapped the service screen's Stop button and never confirmed, then timed out waiting for `porter_server` to exit. All five emulator jobs failed this way on `89e6c89c`.

## Technical Context

- Root cause: `stop_porter()` navigates Home -> service screen -> Stop button, which only opens `StopServiceDialog`. `Shizuku.exit()` runs from that dialog's confirm button, which nothing tapped.
- The dialog uses the same string for its title and its confirm button, so a third `tap("Stop Porter")` is ambiguous. `tap()` gains an `occurrence` index instead of a new matching rule: the service screen has one match, the dialog has two, so asking for the second match both waits for the dialog and selects the confirm button.
- `uiautomator dump` returns only the focused dialog window, not the screen behind it. That is what makes the second match the confirm button rather than the screen's own button, and it is pinned by the fixture in `StopPorterConfirmationTest`.
- The `running-service-dialog` screenshot moves to the confirm tap, so the evidence artifact shows the dialog again instead of the screen it was silently capturing.
- Verified on an API 30 emulator: `emulator-smoke.py` and `compat-install-smoke.py` both pass end to end. CI cannot cover the API 34 TV variant locally; it uses the same plain taps that passed on `b7124e81`.